### PR TITLE
feat: make  `preamble` configurable in ChatCohere

### DIFF
--- a/libs/cohere/langchain_cohere/chat_models.py
+++ b/libs/cohere/langchain_cohere/chat_models.py
@@ -161,6 +161,8 @@ class ChatCohere(BaseChatModel, BaseCohere):
             chat.invoke(messages)
     """
 
+    preamble: Optional[str] = None
+
     class Config:
         """Configuration for this pydantic object."""
 
@@ -178,6 +180,7 @@ class ChatCohere(BaseChatModel, BaseCohere):
         base_params = {
             "model": self.model,
             "temperature": self.temperature,
+            "preamble": self.preamble,
         }
         return {k: v for k, v in base_params.items() if v is not None}
 


### PR DESCRIPTION
As in https://github.com/langchain-ai/langchain/pull/19825, this PR make `preamble` configurable for ChatCohere.