### PR TITLE
RFC: support tool messages in ChatCohere

### DIFF
--- a/libs/cohere/langchain_cohere/chat_models.py
+++ b/libs/cohere/langchain_cohere/chat_models.py
@@ -66,6 +66,11 @@ def _get_tool_results(messages: List[BaseMessage]) -> List[Dict[str, Any]]:
             ]
             if previous_ai_msgs:
                 previous_ai_msg = previous_ai_msgs[-1]
+                tool_message_name: Optional[str] = None
+                if tool_message.name:
+                    tool_message_name = tool_message.name
+                else:
+                    tool_message_name = tool_message.additional_kwargs.get("name")
                 tool_results.extend(
                     [
                         {
@@ -76,8 +81,7 @@ def _get_tool_results(messages: List[BaseMessage]) -> List[Dict[str, Any]]:
                             "outputs": [{"answer": tool_message.content}],
                         }
                         for lc_tool_call in previous_ai_msg.tool_calls
-                        if lc_tool_call["name"]
-                        == tool_message.additional_kwargs.get("name")
+                        if lc_tool_call["name"] == tool_message_name
                     ]
                 )
     return tool_results

--- a/libs/cohere/tests/integration_tests/test_chat_models.py
+++ b/libs/cohere/tests/integration_tests/test_chat_models.py
@@ -7,7 +7,9 @@ import pytest
 from langchain_core.messages import (
     AIMessage,
     AIMessageChunk,
+    HumanMessage,
     ToolCall,
+    ToolMessage,
 )
 from langchain_core.pydantic_v1 import BaseModel, Field
 
@@ -156,3 +158,27 @@ def test_streaming_tool_call_no_tool_calls() -> None:
         acc = chunk if acc is None else acc + chunk
     assert acc.content != ""
     assert "tool_calls" not in acc.additional_kwargs
+
+
+def test_tool_messages() -> None:
+    llm = ChatCohere(temperature=0)
+    messages = [
+        HumanMessage(content="what is the value of magic_function(3)?"),
+        AIMessage(
+            content="",
+            tool_calls=[
+                {
+                    "name": "magic_function",
+                    "args": {"input": 3},
+                    "id": "d86e6098-21e1-44c7-8431-40cfc6d35590",
+                }
+            ],
+        ),
+        ToolMessage(
+            name="magic_function",
+            content="5",
+            tool_call_id="d86e6098-21e1-44c7-8431-40cfc6d35590",
+        ),
+    ]
+    response = llm.invoke(messages)
+    assert isinstance(response, AIMessage)


### PR DESCRIPTION
Langchain today released a new [tool_calls attribute](https://python.langchain.com/docs/modules/model_io/chat/function_calling/) on AIMessage, and these were supported by ChatCohere on release (see https://github.com/langchain-ai/langchain-cohere/pull/7).

Langchain also released a new function for building [tool-calling agents](https://python.langchain.com/docs/modules/agents/agent_types/tool_calling/) that is intended to work with any chat model that supports the new tool calling feature. However, it does not yet work with ChatCohere, and users will receive
`ApiError: status_code: 400, body: {'message': 'invalid request: all elements in history must have a message.'}` if they attempt to use it. A typical flow of messages in this agent framework might look like this:
```python
from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
from langchain_cohere import ChatCohere


llm = ChatCohere(temperature=0)

messages = [
    HumanMessage(content="what is the value of magic_function(3)?"),
    AIMessage(
        content="",
        tool_calls=[
            {
                "name": "magic_function",
                "args": {"input": 3},
                "id": "d86e6098-21e1-44c7-8431-40cfc6d35590",
            }
        ],
    ),
    ToolMessage(
        name="magic_function",
        content="5",
        tool_call_id="d86e6098-21e1-44c7-8431-40cfc6d35590",
    ),
]

response = llm.invoke(messages)
assert isinstance(response, AIMessage)
```
This currently gives the above ApiError. Here we add support for processing tool-calling AI messages and ToolMessages (analogous to Cohere's `tool_result` field). This enables the new tool-calling agent constructor for Cohere:
```python
from langchain.agents import AgentExecutor, create_tool_calling_agent, tool
from langchain_cohere import ChatCohere
from langchain_core.prompts import ChatPromptTemplate, MessagesPlaceholder


prompt = ChatPromptTemplate.from_messages(
    [
        ("system", "You are a helpful assistant"),
        MessagesPlaceholder("chat_history", optional=True),
        ("human", "{input}"),
        MessagesPlaceholder("agent_scratchpad"),
    ]
)

model = ChatCohere()

@tool
def magic_function(input: int) -> int:
    """Applies a magic function to an input."""
    return input + 2


@tool
def get_word_length(word: str) -> int:
    """Returns the length of a word."""
    return len(word)


tools = [magic_function, get_word_length]


agent = create_tool_calling_agent(model, tools, prompt)
agent_executor = AgentExecutor(agent=agent, tools=tools, verbose=True)

agent_executor.invoke(
    {
        "input": (
            "what is the value of magic_function(3)? "
            "also, what is the length of the word 'pumpernickel'?"
        )
    }
)
```
```
> Entering new AgentExecutor chain...

Invoking: `magic_function` with `{'input': 3}`


5
Invoking: `get_word_length` with `{'word': 'pumpernickel'}`


12The value of `magic_function(3)` is 5 and the length of the word 'pumpernickel' is 12.

> Finished chain.
{'input': "what is the value of magic_function(3)? also, what is the length of the word 'pumpernickel'?",
 'output': "The value of `magic_function(3)` is 5 and the length of the word 'pumpernickel' is 12."}
```

### Requests:
- If you have test cases for `cohere_agent.create_cohere_tools_agent`, please supply them so I can compare functionality.
- Please review the `_get_tool_results` function and my changes to the composition of `chat_history` to ensure they make sense.
- Please voice any other feedback or concerns.

Thank you!