### PR TITLE
chore: Add additional CODEOWNER

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -7,4 +7,4 @@
 #
 
 # These owners will be the default owners for everything in the repo.
-* @GangGreenTemperTatum @harry-cohere @BeatrixCohere @billytrend-cohere @minjie-cohere @langchain-ai/langchain-team
+* @GangGreenTemperTatum @harry-cohere @BeatrixCohere @billytrend-cohere @minjie-cohere @langchain-ai/langchain-team @pat-cohere


### PR DESCRIPTION
As discussed - @pat-cohere also has write access, meaning that the CODEOWNERS file is valid