### PR TITLE
patch: add rerank integration test, fix rerank user agent

### DIFF
--- a/libs/cohere/langchain_cohere/rerank.py
+++ b/libs/cohere/langchain_cohere/rerank.py
@@ -22,7 +22,7 @@ class CohereRerank(BaseDocumentCompressor):
     cohere_api_key: Optional[str] = None
     """Cohere API key. Must be specified directly or via environment variable 
         COHERE_API_KEY."""
-    user_agent: str = "langchain"
+    user_agent: str = "langchain:partner"
     """Identifier for the application making the request."""
 
     class Config:
@@ -31,14 +31,14 @@ class CohereRerank(BaseDocumentCompressor):
         extra = Extra.forbid
         arbitrary_types_allowed = True
 
-    @root_validator(pre=True)
+    @root_validator()
     def validate_environment(cls, values: Dict) -> Dict:
         """Validate that api key and python package exists in environment."""
         if not values.get("client"):
             cohere_api_key = get_from_dict_or_env(
                 values, "cohere_api_key", "COHERE_API_KEY"
             )
-            client_name = values.get("user_agent", "langchain")
+            client_name = values.get("user_agent")
             values["client"] = cohere.Client(cohere_api_key, client_name=client_name)
         return values
 

--- a/libs/cohere/langchain_cohere/rerank.py
+++ b/libs/cohere/langchain_cohere/rerank.py
@@ -38,7 +38,7 @@ class CohereRerank(BaseDocumentCompressor):
             cohere_api_key = get_from_dict_or_env(
                 values, "cohere_api_key", "COHERE_API_KEY"
             )
-            client_name = values.get("user_agent")
+            client_name = values["user_agent"]
             values["client"] = cohere.Client(cohere_api_key, client_name=client_name)
         return values
 

--- a/libs/cohere/tests/integration_tests/cassettes/test_langchain_cohere_rerank_with_rank_fields.yaml
+++ b/libs/cohere/tests/integration_tests/cassettes/test_langchain_cohere_rerank_with_rank_fields.yaml
@@ -1,0 +1,71 @@
+interactions:
+- request:
+    body: '{"query": "penguins", "documents": [{"content": "This document is about
+      Penguins.", "subject": "Physics"}, {"content": "This document is about Physics.",
+      "subject": "Penguins"}], "model": "rerank-english-v3.0", "top_n": 3, "rank_fields":
+      ["content"], "max_chunks_per_doc": null}'
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-length:
+      - '278'
+      content-type:
+      - application/json
+      host:
+      - api.cohere.ai
+      user-agent:
+      - python-httpx/0.27.0
+      x-client-name:
+      - langchain:partner
+      x-fern-language:
+      - Python
+      x-fern-sdk-name:
+      - cohere
+      x-fern-sdk-version:
+      - 5.3.0
+    method: POST
+    uri: https://api.cohere.ai/v1/rerank
+  response:
+    body:
+      string: '{"id":"0d4d0075-c857-477e-a2b5-b53ac874e63f","results":[{"index":0,"relevance_score":0.5630176},{"index":1,"relevance_score":0.00007141902}],"meta":{"api_version":{"version":"1"},"billed_units":{"search_units":1}}}'
+    headers:
+      Alt-Svc:
+      - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+      Content-Length:
+      - '214'
+      Via:
+      - 1.1 google
+      access-control-expose-headers:
+      - X-Debug-Trace-ID
+      cache-control:
+      - no-cache, no-store, no-transform, must-revalidate, private, max-age=0
+      content-type:
+      - application/json
+      date:
+      - Wed, 17 Apr 2024 09:11:25 GMT
+      expires:
+      - Thu, 01 Jan 1970 00:00:00 UTC
+      pragma:
+      - no-cache
+      server:
+      - envoy
+      vary:
+      - Origin
+      x-accel-expires:
+      - '0'
+      x-debug-trace-id:
+      - c308db429dcf6ab71d1245fa4effeaf3
+      x-envoy-upstream-service-time:
+      - '50'
+      x-trial-endpoint-call-limit:
+      - '10'
+      x-trial-endpoint-call-remaining:
+      - '8'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/libs/cohere/tests/integration_tests/test_rerank.py
+++ b/libs/cohere/tests/integration_tests/test_rerank.py
@@ -36,4 +36,5 @@ def test_langchain_cohere_rerank_with_rank_fields() -> None:
     response = rerank.rerank(test_documents, test_query, rank_fields=["content"])
     results = {r["index"]: r["relevance_score"] for r in response}
     assert len(results) == 2
+    assert test_documents[0]["content"] == "This document is about Penguins."
     assert results[0] > results[1]

--- a/libs/cohere/tests/integration_tests/test_rerank.py
+++ b/libs/cohere/tests/integration_tests/test_rerank.py
@@ -33,8 +33,10 @@ def test_langchain_cohere_rerank_with_rank_fields() -> None:
         {"content": "This document is about Physics.", "subject": "Penguins"},
     ]
     test_query = "penguins"
+
     response = rerank.rerank(test_documents, test_query, rank_fields=["content"])
+
+    assert len(response) == 2
+    assert response[0]["index"] == 0
     results = {r["index"]: r["relevance_score"] for r in response}
-    assert len(results) == 2
-    assert test_documents[0]["content"] == "This document is about Penguins."
     assert results[0] > results[1]

--- a/libs/cohere/tests/integration_tests/test_rerank.py
+++ b/libs/cohere/tests/integration_tests/test_rerank.py
@@ -6,6 +6,7 @@ https://python.langchain.com/docs/contributing/testing#recording-http-interactio
 
 When re-recording these tests you will need to set COHERE_API_KEY.
 """
+
 import pytest
 from langchain_core.documents import Document
 
@@ -22,3 +23,17 @@ def test_langchain_cohere_rerank_documents() -> None:
     test_query = "Test query"
     results = rerank.rerank(test_documents, test_query)
     assert len(results) == 2
+
+
+@pytest.mark.vcr()
+def test_langchain_cohere_rerank_with_rank_fields() -> None:
+    rerank = CohereRerank()
+    test_documents = [
+        {"content": "This document is about Penguins.", "subject": "Physics"},
+        {"content": "This document is about Physics.", "subject": "Penguins"},
+    ]
+    test_query = "penguins"
+    response = rerank.rerank(test_documents, test_query, rank_fields=["content"])
+    results = {r["index"]: r["relevance_score"] for r in response}
+    assert len(results) == 2
+    assert results[0] > results[1]


### PR DESCRIPTION
Adds an integration test for #12 and fixes an incorrect user agent for the rerank SDK client.