### PR TITLE
patch: add document_ids to CohereCitation

### DIFF
--- a/libs/cohere/langchain_cohere/common.py
+++ b/libs/cohere/langchain_cohere/common.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import Any, List, Mapping
+from typing import Any, List, Mapping, Set
 
 
 @dataclass
@@ -32,5 +32,14 @@ class CohereCitation:
     """
     The contents of the documents that were cited. When used with agents these will be 
     the contents of relevant agent outputs.
+    
+    Every document will have a string field called `id`. This can be used with the 
+    `document_ids` field to deduplicate documents across several citations. The `id` 
+    field is created on the document when it doesn't already exist.
     """
     documents: List[Mapping[str, Any]]
+
+    """
+    A set of the `id` field from all the documents in the `documents` field. 
+    """
+    document_ids: Set[str]

--- a/libs/cohere/langchain_cohere/react_multi_hop/agent.py
+++ b/libs/cohere/langchain_cohere/react_multi_hop/agent.py
@@ -5,7 +5,7 @@
     This agent uses a multi hop prompt by Cohere, which is experimental and subject
     to change. The latest prompt can be used by upgrading the langchain-cohere package.
 """
-from typing import Any, Dict, List, Mapping, Optional, Sequence, Union
+from typing import Any, Dict, List, MutableMapping, Optional, Sequence, Union
 
 from langchain_core.agents import AgentAction, AgentFinish
 from langchain_core.language_models import BaseLanguageModel
@@ -122,7 +122,7 @@ class _AddCitations(Runnable):
 
         # Build a list of documents from the intermediate_steps used in this chain.
         intermediate_steps = input.get("chain_input", {}).get("intermediate_steps", [])
-        documents: List[Mapping] = []
+        documents: List[MutableMapping] = []
         for _, observation in intermediate_steps:
             documents.extend(convert_to_documents(observation))
 

--- a/libs/cohere/langchain_cohere/react_multi_hop/prompt.py
+++ b/libs/cohere/langchain_cohere/react_multi_hop/prompt.py
@@ -7,6 +7,7 @@ from typing import (
     Dict,
     List,
     Mapping,
+    MutableMapping,
     Optional,
     Sequence,
     Tuple,
@@ -139,9 +140,9 @@ def render_observations(
 
 def convert_to_documents(
     observations: Any,
-) -> List[Mapping]:
+) -> List[MutableMapping]:
     """Converts observations into a 'document' dict"""
-    documents: List[Mapping] = []
+    documents: List[MutableMapping] = []
     if isinstance(observations, str):
         # strings are turned into a key/value pair and a key of 'output' is added.
         observations = [{"output": observations}]

--- a/libs/cohere/tests/unit_tests/react_multi_hop/agent/test_add_citations.py
+++ b/libs/cohere/tests/unit_tests/react_multi_hop/agent/test_add_citations.py
@@ -7,7 +7,11 @@ from langchain_core.agents import AgentAction, AgentFinish
 from langchain_cohere import CohereCitation
 from langchain_cohere.react_multi_hop.agent import _AddCitations
 
-CITATIONS = [CohereCitation(start=1, end=2, text="foo", documents=[{"bar": "baz"}])]
+CITATIONS = [
+    CohereCitation(
+        start=1, end=2, text="foo", documents=[{"bar": "baz"}], document_ids={"doc_0"}
+    )
+]
 GENERATION = "mocked generation"
 
 

--- a/libs/cohere/tests/unit_tests/react_multi_hop/parsing/test_parse_citations.py
+++ b/libs/cohere/tests/unit_tests/react_multi_hop/parsing/test_parse_citations.py
@@ -1,4 +1,4 @@
-from typing import List, Mapping
+from typing import List, MutableMapping
 
 import pytest
 
@@ -24,7 +24,11 @@ DOCUMENTS = [{"foo": "bar"}, {"baz": "foobar"}]
             "with one citation.",
             [
                 CohereCitation(
-                    start=5, end=17, text="one citation", documents=[DOCUMENTS[0]]
+                    start=5,
+                    end=17,
+                    text="one citation",
+                    documents=[DOCUMENTS[0]],
+                    document_ids={"doc_0"},
                 )
             ],
             id="one citation (normal)",
@@ -39,6 +43,7 @@ DOCUMENTS = [{"foo": "bar"}, {"baz": "foobar"}]
                     end=18,
                     text="two documents",
                     documents=[DOCUMENTS[0], DOCUMENTS[1]],
+                    document_ids={"doc_0", "doc_1"},
                 )
             ],
             id="two cited documents (normal)",
@@ -48,9 +53,19 @@ DOCUMENTS = [{"foo": "bar"}, {"baz": "foobar"}]
             DOCUMENTS,
             "with two citations.",
             [
-                CohereCitation(start=5, end=8, text="two", documents=[DOCUMENTS[0]]),
                 CohereCitation(
-                    start=9, end=18, text="citations", documents=[DOCUMENTS[1]]
+                    start=5,
+                    end=8,
+                    text="two",
+                    documents=[DOCUMENTS[0]],
+                    document_ids={"doc_0"},
+                ),
+                CohereCitation(
+                    start=9,
+                    end=18,
+                    text="citations",
+                    documents=[DOCUMENTS[1]],
+                    document_ids={"doc_1"},
                 ),
             ],
             id="more than one citation (normal)",
@@ -65,6 +80,7 @@ DOCUMENTS = [{"foo": "bar"}, {"baz": "foobar"}]
                     end=23,
                     text="incorrect citation",
                     documents=[],  # note no documents.
+                    document_ids=set(),
                 )
             ],
             id="cited document doesn't exist (abnormal)",
@@ -73,7 +89,7 @@ DOCUMENTS = [{"foo": "bar"}, {"baz": "foobar"}]
 )
 def test_parse_citations(
     text: str,
-    documents: List[Mapping],
+    documents: List[MutableMapping],
     expected_generation: str,
     expected_citations: List[CohereCitation],
 ) -> None:


### PR DESCRIPTION
This PR adds a field called `id` to each cited document (if not already present), and returns a set of cited ids with every citation. This citation object is only currently used on the multihop agent (a different citation object is present on other agents and the rag retriever, but we hope to consolidate this at some point).

`ids` are arbitrary - their purpose it to uniquely identify a document and the format may change at a later date.

This addition should be useful for applications that wish to return one collection of cited documents together with many citations without having to return lots of documents. For example:

```python3
... agent executor output ...

result = agent_executor.invoke("In what year was the company that was founded as Sound of Music added to the S&P 500?")

# Builds a unique list of cited documents
cited_documents = []
cited_document_ids = []
for citation in result["citations"]:
   for document in citation.documents:
       if document.id in cited_document_ids:
           continue
      cited_documents.append(document)
      cited_document_ids.append(document.id)
   
return result["output"], result["citations"], cited_documents
```