### PR TITLE
fix: add preamble field to base_params

### DIFF
--- a/libs/cohere/langchain_cohere/chat_models.py
+++ b/libs/cohere/langchain_cohere/chat_models.py
@@ -286,6 +286,7 @@ class ChatCohere(BaseChatModel, BaseCohere):
         base_params = {
             "model": self.model,
             "temperature": self.temperature,
+            "preamble": self.preamble,
         }
         return {k: v for k, v in base_params.items() if v is not None}
 

--- a/libs/cohere/tests/unit_tests/test_chat_models.py
+++ b/libs/cohere/tests/unit_tests/test_chat_models.py
@@ -19,10 +19,13 @@ def test_initialization() -> None:
     [
         pytest.param(ChatCohere(cohere_api_key="test"), {}, id="defaults"),
         pytest.param(
-            ChatCohere(cohere_api_key="test", model="foo", temperature=1.0),
+            ChatCohere(
+                cohere_api_key="test", model="foo", temperature=1.0, preamble="bar"
+            ),
             {
                 "model": "foo",
                 "temperature": 1.0,
+                "preamble": "bar",
             },
             id="values are set",
         ),


### PR DESCRIPTION
It appears that the changes made to the preamble parameter in #3 were accidentally removed with  #18 so this pull request have re-added it.
In the current version, the preamble can be specified, but it is not working at all.