### PR TITLE
add standard params

### DIFF
--- a/libs/cohere/langchain_cohere/chat_models.py
+++ b/libs/cohere/langchain_cohere/chat_models.py
@@ -497,17 +497,17 @@ class ChatCohere(BaseChatModel, BaseCohere):
             raise Exception("invalid cohere list models response")
         return response.models[0].name
 
+    @property
+    def model_name(self) -> str:
+        if self.model is not None:
+            return self.model
+        if self._default_model_name is None:
+            self._default_model_name = self._get_default_model()
+        return self._default_model_name
+
     def get_num_tokens(self, text: str) -> int:
         """Calculate number of tokens."""
-        model: str
-        if self.model is not None:
-            model = self.model
-        elif self._default_model_name is not None:
-            model = self._default_model_name
-        else:
-            model = self._get_default_model()
-            self._default_model_name = model
-
+        model = self.model_name
         return len(self.client.tokenize(text=text, model=model).tokens)
 
 

--- a/libs/cohere/poetry.lock
+++ b/libs/cohere/poetry.lock
@@ -883,7 +883,7 @@ subdirectory = "libs/langchain"
 
 [[package]]
 name = "langchain-core"
-version = "0.2.0rc1"
+version = "0.2.3"
 description = "Building applications with LLMs through composability"
 optional = false
 python-versions = ">=3.8.1,<4.0"
@@ -892,7 +892,7 @@ develop = false
 
 [package.dependencies]
 jsonpatch = "^1.33"
-langsmith = "^0.1.0"
+langsmith = "^0.1.65"
 packaging = "^23.2"
 pydantic = ">=1,<3"
 PyYAML = ">=5.3"
@@ -905,7 +905,7 @@ extended-testing = ["jinja2 (>=3,<4)"]
 type = "git"
 url = "https://github.com/langchain-ai/langchain.git"
 reference = "HEAD"
-resolved_reference = "04059339148e0870642ff6dae552172671c884de"
+resolved_reference = "afe89a141107f0af79446533614386a4459510bc"
 subdirectory = "libs/core"
 
 [[package]]
@@ -932,13 +932,13 @@ subdirectory = "libs/text-splitters"
 
 [[package]]
 name = "langsmith"
-version = "0.1.58"
+version = "0.1.67"
 description = "Client library to connect to the LangSmith LLM Tracing and Evaluation Platform."
 optional = false
 python-versions = "<4.0,>=3.8.1"
 files = [
-    {file = "langsmith-0.1.58-py3-none-any.whl", hash = "sha256:1148cc836ec99d1b2f37cd2fa3014fcac213bb6bad798a2b21bb9111c18c9768"},
-    {file = "langsmith-0.1.58.tar.gz", hash = "sha256:a5060933c1fb3006b498ec849677993329d7e6138bdc2ec044068ab806e09c39"},
+    {file = "langsmith-0.1.67-py3-none-any.whl", hash = "sha256:7eb2e1c1b375925ff47700ed8071e10c15e942e9d1d634b4a449a9060364071a"},
+    {file = "langsmith-0.1.67.tar.gz", hash = "sha256:149558669a2ac4f21471cd964e61072687bba23b7c1ccb51f190a8f59b595b39"},
 ]
 
 [package.dependencies]
@@ -2224,4 +2224,4 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8.1,<4.0"
-content-hash = "0a484048a9844f7bfe76b87dd0dd1ffcf1326fc93ac3e5f2da8d8060b78263fe"
+content-hash = "09a18b6681478d705553ae00fa0ef7d18772e33e550338bc40c501108adcfcfa"

--- a/libs/cohere/pyproject.toml
+++ b/libs/cohere/pyproject.toml
@@ -12,7 +12,7 @@ license = "MIT"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"
-langchain-core = ">=0.1.42,<0.3"
+langchain-core = ">=0.2.0,<0.3"
 cohere = ">=5.5.3,<6.0"
 
 [tool.poetry.group.test]


### PR DESCRIPTION
Here we implement a set of [parameters](https://github.com/langchain-ai/langchain/blob/2316635adda5db75a9773a995f790079fdfbc647/libs/core/langchain_core/language_models/chat_models.py#L66) that LangChain is standardizing on to simplify integrations with various LLM monitoring platforms (such as Langsmith). These include standard keys for providers, model names, temperature, stop sequences, etc.

`ChatCohere` is somewhat distinct in that the `.model` attribute can be None. Because we always require a string for the model name parameter, I also add a property `.model_name` that will cache the result of `._get_default_model()` if `.model` is None. I took this from the `get_num_tokens` method and refactored `get_num_tokens` to use it. I don't actually know if this is the model that is used behind the scenes when `model=None`!

Note that we will generally now be calling `._get_default_model()` (which makes an additional network call) whenever we first invoke ChatCohere after it's instantiated with no value for `model`.

We also bump langchain-core to 0.2.0. This is needed to support the new parameters. There are no breaking changes in langchain-core from 0.1 to 0.2, but let me know if you think we'd need to update langchain-cohere to 0.2 as well due to this (we have not been doing this in other integration packages).