### PR TITLE
fix integration tests

### DIFF
--- a/libs/cohere/tests/integration_tests/react_multi_hop/test_cohere_react_agent.py
+++ b/libs/cohere/tests/integration_tests/react_multi_hop/test_cohere_react_agent.py
@@ -16,10 +16,12 @@ from langchain_core.tools import BaseTool
 
 from langchain_cohere import ChatCohere, create_cohere_react_agent
 
+DEFAULT_MODEL = "command-r"
+
 
 @pytest.mark.vcr()
 def test_invoke_multihop_agent() -> None:
-    llm = ChatCohere(temperature=0.0)
+    llm = ChatCohere(model=DEFAULT_MODEL, temperature=0.0)
 
     class _InputSchema(BaseModel):
         query: str = Field(description="Query to search the internet with")

--- a/libs/cohere/tests/integration_tests/test_chat_models.py
+++ b/libs/cohere/tests/integration_tests/test_chat_models.py
@@ -23,11 +23,13 @@ from langchain_core.tools import tool
 
 from langchain_cohere import ChatCohere
 
+DEFAULT_MODEL = "command-r"
+
 
 @pytest.mark.vcr()
 def test_stream() -> None:
     """Test streaming tokens from ChatCohere."""
-    llm = ChatCohere()
+    llm = ChatCohere(model=DEFAULT_MODEL)
 
     for token in llm.stream("I'm Pickle Rick"):
         assert isinstance(token.content, str)
@@ -36,7 +38,7 @@ def test_stream() -> None:
 @pytest.mark.vcr()
 async def test_astream() -> None:
     """Test streaming tokens from ChatCohere."""
-    llm = ChatCohere()
+    llm = ChatCohere(model=DEFAULT_MODEL)
 
     async for token in llm.astream("I'm Pickle Rick"):
         assert isinstance(token.content, str)
@@ -44,7 +46,7 @@ async def test_astream() -> None:
 
 async def test_abatch() -> None:
     """Test streaming tokens from ChatCohere"""
-    llm = ChatCohere()
+    llm = ChatCohere(model=DEFAULT_MODEL)
 
     result = await llm.abatch(["I'm Pickle Rick", "I'm not Pickle Rick"])
     for token in result:
@@ -53,7 +55,7 @@ async def test_abatch() -> None:
 
 async def test_abatch_tags() -> None:
     """Test batch tokens from ChatCohere."""
-    llm = ChatCohere()
+    llm = ChatCohere(model=DEFAULT_MODEL)
 
     result = await llm.abatch(
         ["I'm Pickle Rick", "I'm not Pickle Rick"], config={"tags": ["foo"]}
@@ -65,7 +67,7 @@ async def test_abatch_tags() -> None:
 @pytest.mark.vcr()
 def test_batch() -> None:
     """Test batch tokens from ChatCohere."""
-    llm = ChatCohere()
+    llm = ChatCohere(model=DEFAULT_MODEL)
 
     result = llm.batch(["I'm Pickle Rick", "I'm not Pickle Rick"])
     for token in result:
@@ -74,16 +76,16 @@ def test_batch() -> None:
 
 async def test_ainvoke() -> None:
     """Test invoke tokens from ChatCohere."""
-    llm = ChatCohere()
+    llm = ChatCohere(model=DEFAULT_MODEL)
 
     result = await llm.ainvoke("I'm Pickle Rick", config={"tags": ["foo"]})
     assert isinstance(result.content, str)
 
 
-@pytest.mark.vcr()
+# @pytest.mark.vcr()
 def test_invoke() -> None:
     """Test invoke tokens from ChatCohere."""
-    llm = ChatCohere()
+    llm = ChatCohere(model=DEFAULT_MODEL)
 
     result = llm.invoke("I'm Pickle Rick", config=dict(tags=["foo"]))
     assert isinstance(result.content, str)
@@ -91,7 +93,7 @@ def test_invoke() -> None:
 
 @pytest.mark.vcr()
 def test_invoke_tool_calls() -> None:
-    llm = ChatCohere(temperature=0)
+    llm = ChatCohere(model=DEFAULT_MODEL, temperature=0)
 
     class Person(BaseModel):
         name: str = Field(type=str, description="The name of the person")
@@ -119,7 +121,7 @@ def test_invoke_tool_calls() -> None:
 
 @pytest.mark.vcr()
 def test_streaming_tool_call() -> None:
-    llm = ChatCohere(temperature=0)
+    llm = ChatCohere(model=DEFAULT_MODEL, temperature=0)
 
     class Person(BaseModel):
         name: str = Field(type=str, description="The name of the person")
@@ -155,7 +157,7 @@ def test_streaming_tool_call() -> None:
 
 @pytest.mark.vcr()
 def test_invoke_multiple_tools() -> None:
-    llm = ChatCohere(temperature=0)
+    llm = ChatCohere(model=DEFAULT_MODEL, temperature=0)
 
     @tool
     def add_two_numbers(a: int, b: int) -> int:
@@ -185,7 +187,7 @@ def test_invoke_multiple_tools() -> None:
     reason="Cohere models return empty output when a tool is passed in but not called."
 )
 def test_streaming_tool_call_no_tool_calls() -> None:
-    llm = ChatCohere(temperature=0)
+    llm = ChatCohere(model=DEFAULT_MODEL, temperature=0)
 
     class Person(BaseModel):
         name: str = Field(type=str, description="The name of the person")
@@ -215,7 +217,7 @@ def test_get_num_tokens_with_specified_model() -> None:
 
 @pytest.mark.vcr()
 def test_get_num_tokens_with_default_model() -> None:
-    llm = ChatCohere(temperature=0)
+    llm = ChatCohere(model=DEFAULT_MODEL, temperature=0)
     expected = 3  # This may change if the replay also changes.
 
     actual = llm.get_num_tokens("hello, world")
@@ -250,6 +252,6 @@ def test_get_num_tokens_with_default_model() -> None:
     ],
 )
 def test_tool_call_with_tool_results(messages: List[BaseMessage]) -> None:
-    llm = ChatCohere(temperature=0)
+    llm = ChatCohere(model=DEFAULT_MODEL, temperature=0)
     response = llm.invoke(messages)
     assert isinstance(response, AIMessage)

--- a/libs/cohere/tests/integration_tests/test_langgraph_agents.py
+++ b/libs/cohere/tests/integration_tests/test_langgraph_agents.py
@@ -18,6 +18,8 @@ from langchain_core.tools import BaseTool, Tool
 
 from langchain_cohere import ChatCohere
 
+DEFAULT_MODEL = "command-r"
+
 
 @pytest.mark.skipif(sys.version_info < (3, 9), reason="requires >= python3.9")
 @pytest.mark.vcr()
@@ -55,7 +57,7 @@ def test_langgraph_react_agent() -> None:
     system_message = "You are a helpful assistant. Respond only in English."
 
     tools = [web_search, python_tool]
-    model = ChatCohere()
+    model = ChatCohere(model=DEFAULT_MODEL)
 
     app = create_react_agent(model, tools, messages_modifier=system_message)
 
@@ -103,7 +105,7 @@ def test_langchain_tool_calling_agent() -> None:
     magic_function_tool.args_schema = MagicFunctionInput
 
     tools: Sequence[BaseTool] = [magic_function_tool]
-    model = ChatCohere()
+    model = ChatCohere(model=DEFAULT_MODEL)
 
     query = "what is the value of magic_function(3)?"
 

--- a/libs/cohere/tests/integration_tests/test_rag.py
+++ b/libs/cohere/tests/integration_tests/test_rag.py
@@ -20,11 +20,13 @@ from langchain_core.runnables import (
 
 from langchain_cohere import ChatCohere, CohereRagRetriever
 
+DEFAULT_MODEL = "command-r"
+
 
 @pytest.mark.vcr()
 def test_connectors() -> None:
     """Test connectors parameter support from ChatCohere."""
-    llm = ChatCohere().bind(connectors=[{"id": "web-search"}])
+    llm = ChatCohere(model=DEFAULT_MODEL).bind(connectors=[{"id": "web-search"}])
 
     result = llm.invoke("Who directed dune two? reply with just the name.")
     assert isinstance(result.content, str)
@@ -33,7 +35,7 @@ def test_connectors() -> None:
 @pytest.mark.vcr()
 def test_documents() -> None:
     docs = [{"text": "The sky is green."}]
-    llm = ChatCohere().bind(documents=docs)
+    llm = ChatCohere(model=DEFAULT_MODEL).bind(documents=docs)
     prompt = "What color is the sky?"
 
     result = llm.invoke(prompt)
@@ -43,7 +45,7 @@ def test_documents() -> None:
 
 @pytest.mark.vcr()
 def test_documents_chain() -> None:
-    llm = ChatCohere()
+    llm = ChatCohere(model=DEFAULT_MODEL)
 
     def get_documents(_: Any) -> List[Document]:
         return [Document(page_content="The sky is green.")]
@@ -75,7 +77,7 @@ def test_documents_chain() -> None:
 @pytest.mark.vcr()
 def test_who_are_cohere() -> None:
     user_query = "Who founded Cohere?"
-    llm = ChatCohere()
+    llm = ChatCohere(model=DEFAULT_MODEL)
     retriever = CohereRagRetriever(llm=llm, connectors=[{"id": "web-search"}])
 
     actual = retriever.get_relevant_documents(user_query)
@@ -93,7 +95,7 @@ def test_who_are_cohere() -> None:
 
 @pytest.mark.vcr()
 def test_who_founded_cohere_with_custom_documents() -> None:
-    rag = CohereRagRetriever(llm=ChatCohere())
+    rag = CohereRagRetriever(llm=ChatCohere(model=DEFAULT_MODEL))
 
     docs = rag.invoke(
         "who is the founder of cohere?",

--- a/libs/cohere/tests/integration_tests/test_tool_calling_agent.py
+++ b/libs/cohere/tests/integration_tests/test_tool_calling_agent.py
@@ -35,7 +35,7 @@ from langchain_cohere import ChatCohere
     ],
 )
 def test_tool_calling_agent(messages: List[BaseMessage], expected_content: str) -> None:
-    llm = ChatCohere()
+    llm = ChatCohere(model="command-r")
 
     actual = llm.invoke(messages)
     actual_citations = actual.additional_kwargs.get("citations")


### PR DESCRIPTION
Following https://github.com/langchain-ai/langchain-cohere/pull/52, initializing `ChatCohere()` without specifying the model name calls `._get_default_model()` to fetch the name for tracing purposes. This generates a network call (a GET request to the `models` endpoint) that is not recorded in pytest-vcr cassettes.

Here, we specify a model during integration tests. I felt this was also a generally good idea for consistency and transparency. If we prefer we can update the cassettes instead.