### PR TITLE
Fix: add missing enumeration and index when `force_single_step=True`

### DIFF
--- a/libs/cohere/langchain_cohere/chat_models.py
+++ b/libs/cohere/langchain_cohere/chat_models.py
@@ -290,7 +290,7 @@ def get_cohere_chat_request(
     else:
         message_str = ""
         # if force_single_step is set to True, then message is the last human message in the conversation  # noqa: E501
-        for message in messages[:-1]:
+        for i, message in enumerate(messages[:-1]):
             if isinstance(message, AIMessage) and message.tool_calls:
                 continue
 


### PR DESCRIPTION
Fix for error:
```
File "/.../site-packages/langchain_core/language_models/chat_models.py", line 668, in agenerate
    raise exceptions[0]
File "/.../site-packages/langchain_core/language_models/chat_models.py", line 841, in _agenerate_with_cache
    async for chunk in self._astream(messages, stop=stop, **kwargs):
File "/.../site-packages/langchain_cohere/chat_models.py", line 508, in _astream
    request = get_cohere_chat_request(
              ^^^^^^^^^^^^^^^^^^^^^^^^
File "/.../site-packages/langchain_cohere/chat_models.py", line 299, in get_cohere_chat_request
    temp_tool_results += _message_to_cohere_tool_results(messages, i)
                                                         ^^^^^^^^
UnboundLocalError: cannot access local variable 'i' where it is not associated with a value
```