### PR TITLE
chore: bump langchain-cohere version

### DIFF
--- a/libs/cohere/poetry.lock
+++ b/libs/cohere/poetry.lock
@@ -999,13 +999,13 @@ subdirectory = "libs/langgraph"
 
 [[package]]
 name = "langsmith"
-version = "0.1.93"
+version = "0.1.94"
 description = "Client library to connect to the LangSmith LLM Tracing and Evaluation Platform."
 optional = false
 python-versions = "<4.0,>=3.8.1"
 files = [
-    {file = "langsmith-0.1.93-py3-none-any.whl", hash = "sha256:811210b9d5f108f36431bd7b997eb9476a9ecf5a2abd7ddbb606c1cdcf0f43ce"},
-    {file = "langsmith-0.1.93.tar.gz", hash = "sha256:285b6ad3a54f50fa8eb97b5f600acc57d0e37e139dd8cf2111a117d0435ba9b4"},
+    {file = "langsmith-0.1.94-py3-none-any.whl", hash = "sha256:0d01212086d58699f75814117b026784218042f7859877ce08a248a98d84aa8d"},
+    {file = "langsmith-0.1.94.tar.gz", hash = "sha256:e44afcdc9eee6f238f6a87a02bba83111bd5fad376d881ae299834e06d39d712"},
 ]
 
 [package.dependencies]

--- a/libs/cohere/pyproject.toml
+++ b/libs/cohere/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "langchain-cohere"
-version = "0.2.0rc2"
+version = "0.2.0"
 description = "An integration package connecting Cohere and LangChain"
 authors = []
 readme = "README.md"


### PR DESCRIPTION
Bump the langchain-cohere version to 0.2.0 - minor version release cut out at this point.