### PR TITLE
Update parsing.py

### DIFF
--- a/libs/cohere/langchain_cohere/react_multi_hop/parsing.py
+++ b/libs/cohere/langchain_cohere/react_multi_hop/parsing.py
@@ -132,6 +132,7 @@ def parse_answer_with_prefixes(
 def parse_actions(generation: str) -> Tuple[str, str, List[Dict]]:
     """Parse action selections from model output."""
     plan = ""
+    generation = generation.strip()
     actions = generation
     try:
         if "Plan: " in generation or "Reflection: " in generation:


### PR DESCRIPTION
strip generation before action parsing to handle case of leading whitespace/newline causing regex match failure