### PR TITLE
Fix embedding extraction when using EmbeddingsByType

### DIFF
--- a/libs/cohere/langchain_cohere/embeddings.py
+++ b/libs/cohere/langchain_cohere/embeddings.py
@@ -139,7 +139,7 @@ class CohereEmbeddings(BaseModel, Embeddings):
             input_type=input_type,
             truncate=self.truncate,
             embedding_types=self.embedding_types,
-        ).embeddings
+        ).embeddings.float
         return [list(map(float, e)) for e in embeddings]
 
     async def aembed(
@@ -156,7 +156,7 @@ class CohereEmbeddings(BaseModel, Embeddings):
                 truncate=self.truncate,
                 embedding_types=self.embedding_types,
             )
-        ).embeddings
+        ).embeddings.float
         return [list(map(float, e)) for e in embeddings]
 
     def embed_documents(self, texts: List[str]) -> List[List[float]]:

--- a/libs/cohere/tests/integration_tests/test_embeddings.py
+++ b/libs/cohere/tests/integration_tests/test_embeddings.py
@@ -26,3 +26,23 @@ def test_langchain_cohere_embedding_query() -> None:
     embedding = CohereEmbeddings(model="embed-english-light-v3.0")
     output = embedding.embed_query(document)
     assert len(output) > 0
+
+
+@pytest.mark.vcr()
+def test_langchain_cohere_embedding_float() -> None:
+    document = "foo bar"
+    embedding = CohereEmbeddings(model="embed-english-light-v3.0")
+    # Call the embed_with_retry directly, rather than through `embed_query`
+    # or `embed_documents` so that we can verify the correct fields are
+    # present in the response.
+    output = embedding.embed_with_retry(
+        model=embedding.model,
+        texts=[document],
+        input_type="search_query",
+        truncate=embedding.truncate,
+        embedding_types=embedding.embedding_types,
+    )
+    assert output
+    assert output.embeddings
+    assert output.embeddings.float
+    assert len(output.embeddings.float) > 0


### PR DESCRIPTION
Hello! I wanted to take a stab at fixing #81 as it's a blocker for upgrading to LangChain v0.2, but wasn't entirely clear on your contribution guidelines wrt preferred approach, linting, format, etc. Happy to adjust as necessary!

Since the Cohere API is now returning an embeddings object labelled per vector datatype, the existing `map()` logic over the response tries to convert the `float_` string to a `float` and raises an exception.

To resolve this, I'm simply accessing the internal `float` object. Now, this doesn't account for when a user requests their embeddings as different datatypes, but it's at least a start to the conversation. I would imagine that if the user requests something other than or in addition to `float`, then one would need to pull that out and return it as well. In that case, it's not a one-to-one mapping of input queries/docs to embeddings, so what does the return look like, aaaand you see why I'm stopping before I get too far. 😄 

I also added an integration test for this situation. Note that the cassettes for embedding tests have older cached responses that don't reflect what the API presently returns. I haven't updated these, but can definitely do so later if this PR was to proceed.

Thanks!