### PR TITLE
chore: Support JSON schema tool definitions in react agent prompt

### DIFF
--- a/libs/cohere/langchain_cohere/react_multi_hop/prompt.py
+++ b/libs/cohere/langchain_cohere/react_multi_hop/prompt.py
@@ -86,8 +86,44 @@ def render_structured_preamble(
     )
 
 
-def render_tool(tool: BaseTool) -> str:
-    """Renders a tool into prompt content"""
+def render_tool(
+    tool: Optional[BaseTool] = None,
+    json_schema: Optional[Dict] = None,
+) -> str:
+    """Renders a tool into prompt content. Either a BaseTool instance, or, a JSON
+     schema must be provided.
+
+    Args:
+        tool: An instance of a BaseTool.
+        json_schema: A dictionary containing the JSON schema representation of a tool.
+
+    Returns:
+        A string of prompt content.
+
+    Example:
+
+        .. code-block:: python
+
+        from langchain_cohere.react_multi_hop.prompt import render_tool
+
+        json_schema = {
+            "name": "example_tool",
+            "description": "A description of example_tool",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "foo": {"type": "string", "description": "A description of foo"},
+                    "bar": {"type": "integer", "description": "A description of bar"},
+                },
+                "required": ["foo"],
+            },
+        }
+        print(render_tool(json_schema=json_schema))
+
+        tool = MyTool()
+        print(render_tool(tool=tool))
+
+    """
 
     template = """```python
 {tool_signature}
@@ -95,12 +131,38 @@ def render_tool(tool: BaseTool) -> str:
     \"\"\"
     pass
 ```"""
+    assert (
+        tool is not None or json_schema is not None
+    ), "Either a BaseTool instance or JSON schema must be provided."
+
+    if tool is not None:
+        assert tool is not None  # for type checkers
+        tool_name = tool.name
+        tool_description = tool.description
+        tool_args = tool.args
+        required_parameters = []
+        for parameter_name, parameter_definition in tool_args.items():
+            if "default" not in parameter_definition:
+                required_parameters.append(parameter_name)
+    else:
+        assert json_schema is not None  # for type checkers
+        tool_name = json_schema.get("name", "")
+        tool_description = json_schema.get("description", "")
+        tool_args = json_schema.get("parameters", {}).get("properties", {})
+        required_parameters = json_schema.get("parameters", {}).get("required", [])
+
     return template.format(
-        tool_signature=render_tool_signature(tool),
-        tool_description=_remove_signature_from_tool_description(
-            tool.name, tool.description
+        tool_signature=_render_tool_signature(
+            tool_name=tool_name,
+            tool_args=tool_args,
+            required_parameters=required_parameters,
         ),
-        tool_args=render_tool_args(tool),
+        tool_description=_remove_signature_from_tool_description(
+            name=tool_name, description=tool_description
+        ),
+        tool_args=_render_tool_args(
+            tool_args=tool_args, required_parameters=required_parameters
+        ),
     )
 
 
@@ -213,7 +275,7 @@ def multi_hop_prompt(
     return inner
 
 
-def render_type(type_: str, is_optional: bool) -> str:
+def _render_type(type_: str, is_optional: bool) -> str:
     """
     Renders a tool's type into prompt content. Types should be Python types, but JSON
     schema is allowed and converted.
@@ -225,30 +287,34 @@ def render_type(type_: str, is_optional: bool) -> str:
         return python_type
 
 
-def render_tool_signature(tool: BaseTool) -> str:
+def _render_tool_signature(
+    tool_name: str, tool_args: Dict, required_parameters: List
+) -> str:
     """Renders the signature of a tool into prompt content."""
     args = []
-    for parameter_name, parameter_definition in tool.args.items():
-        type_ = render_type(
-            parameter_definition.get("type"), "default" in parameter_definition
+    for parameter_name, parameter_definition in tool_args.items():
+        type_ = _render_type(
+            type_=parameter_definition.get("type"),
+            is_optional=parameter_name not in required_parameters,
         )
         args.append(f"{parameter_name}: {type_}")
     signature = ", ".join(args)
-    return f"def {tool.name}({signature}) -> List[Dict]:"
+    return f"def {tool_name}({signature}) -> List[Dict]:"
 
 
-def render_tool_args(tool: BaseTool) -> str:
+def _render_tool_args(tool_args: Dict, required_parameters: List[str]) -> str:
     """Renders the 'Args' section of a tool's prompt content."""
-    if not tool.args:
+    if not tool_args:
         return ""
     indent = " "
 
     prompt_content = f"\n\n{indent * 4}Args:\n{indent * 8}"
 
     rendered_args = []
-    for parameter_name, parameter_definition in tool.args.items():
-        type_ = render_type(
-            parameter_definition.get("type"), "default" in parameter_definition
+    for parameter_name, parameter_definition in tool_args.items():
+        type_ = _render_type(
+            type_=parameter_definition.get("type"),
+            is_optional=parameter_name not in required_parameters,
         )
         description = parameter_definition.get("description", "")
         rendered_args.append(f"{parameter_name} ({type_}): {description}")

--- a/libs/cohere/pyproject.toml
+++ b/libs/cohere/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "langchain-cohere"
-version = "0.2.3"
+version = "0.2.4"
 description = "An integration package connecting Cohere and LangChain"
 authors = []
 readme = "README.md"

--- a/libs/cohere/tests/unit_tests/react_multi_hop/data/tools/default.txt
+++ b/libs/cohere/tests/unit_tests/react_multi_hop/data/tools/default.txt
@@ -1,0 +1,10 @@
+```python
+def example_tool(foo: str, bar: Optional[int]) -> List[Dict]:
+    """A description of example_tool
+
+    Args:
+        foo (str): A description of foo
+        bar (Optional[int]): A description of bar
+    """
+    pass
+```

--- a/libs/cohere/tests/unit_tests/react_multi_hop/data/tools/without_args.txt
+++ b/libs/cohere/tests/unit_tests/react_multi_hop/data/tools/without_args.txt
@@ -1,0 +1,6 @@
+```python
+def example_tool() -> List[Dict]:
+    """A description of example_tool
+    """
+    pass
+```

--- a/libs/cohere/tests/unit_tests/react_multi_hop/data/tools/without_description.txt
+++ b/libs/cohere/tests/unit_tests/react_multi_hop/data/tools/without_description.txt
@@ -1,0 +1,10 @@
+```python
+def example_tool(foo: str, bar: Optional[int]) -> List[Dict]:
+    """
+
+    Args:
+        foo (str): A description of foo
+        bar (Optional[int]): A description of bar
+    """
+    pass
+```

--- a/libs/cohere/tests/unit_tests/react_multi_hop/prompt/test_render_tool.py
+++ b/libs/cohere/tests/unit_tests/react_multi_hop/prompt/test_render_tool.py
@@ -1,0 +1,110 @@
+from pathlib import Path
+from typing import Any, Dict, Type
+
+import pytest
+from langchain_core.tools import BaseTool
+from pydantic import BaseModel, Field
+
+from langchain_cohere.react_multi_hop.prompt import render_tool
+
+DATA_DIR = Path(__file__).parents[1] / "data" / "tools"
+
+
+class ExampleToolWithArgs(BaseTool):
+    class _args_schema(BaseModel):
+        foo: str = Field(description="A description of foo")
+        bar: int = Field(description="A description of bar", default=None)
+
+    name = "example_tool"
+    description = "A description of example_tool"
+    args_schema: Type[BaseModel] = _args_schema  # type: ignore
+
+    def _run(self, *args: Any, **kwargs: Any) -> Any:
+        pass
+
+
+example_tool = ExampleToolWithArgs()
+
+json_schema = {
+    "name": "example_tool",
+    "description": "A description of example_tool",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "foo": {"type": "string", "description": "A description of foo"},
+            "bar": {"type": "integer", "description": "A description of bar"},
+        },
+        "required": ["foo"],
+    },
+}
+
+without_description = ExampleToolWithArgs()
+without_description.description = ""
+
+
+class ExampleToolWithoutArgs(BaseTool):
+    class _args_schema(BaseModel):
+        pass
+
+    name = "example_tool"
+    description = "A description of example_tool"
+    args_schema: Type[BaseModel] = _args_schema  # type: ignore
+
+    def _run(self, *args: Any, **kwargs: Any) -> Any:
+        pass
+
+
+example_tool_without_args = ExampleToolWithoutArgs()
+
+json_schema_without_args = {
+    "name": "example_tool",
+    "description": "A description of example_tool",
+}
+
+
+@pytest.mark.parametrize(
+    "expected_contents,tool,json_schema",
+    [
+        pytest.param(
+            DATA_DIR / "default.txt", example_tool, None, id="basetool - default"
+        ),
+        pytest.param(
+            DATA_DIR / "default.txt",
+            None,
+            json_schema,
+            id="json schema - default",
+        ),
+        pytest.param(
+            DATA_DIR / "without_description.txt",
+            without_description,
+            None,
+            id="basetool - without description",
+        ),
+        pytest.param(
+            DATA_DIR / "without_args.txt",
+            None,
+            json_schema_without_args,
+            id="json schema - without args",
+        ),
+        pytest.param(
+            DATA_DIR / "without_args.txt",
+            example_tool_without_args,
+            None,
+            id="basetool - without args",
+        ),
+    ],
+)
+def test_render_tool(
+    expected_contents: Path,
+    tool: BaseTool,
+    json_schema: Dict,
+) -> None:
+    with open(expected_contents, "r") as f:
+        expected = f.read().rstrip("\n")
+
+    actual = render_tool(
+        tool=tool,
+        json_schema=json_schema,
+    )
+
+    assert actual == expected


### PR DESCRIPTION
Reusing the open sourced prompts as part of LangChain's prompting framework, but not necessarily using the agent framework, is useful. Currently this is possible for all parts of the react agent's prompts _except_ tool definitions.

This PR adds support for rendering JSON schema definitions. This is useful when you're only using the prompts and your tool definition doesn't convert to a LangChain tool - for example, an existing library of tools that aren't already LC tools, or tools that don't encode to JSON.