### PR TITLE
infra: revert toggled default

### DIFF
--- a/.github/workflows/_release.yml
+++ b/.github/workflows/_release.yml
@@ -227,6 +227,7 @@ jobs:
           packages-dir: ${{ inputs.working-directory }}/dist/
           verbose: true
           print-hash: true
+          attestations: false
 
   mark-release:
     needs:


### PR DESCRIPTION
[Digital attestations ](https://blog.pypi.org/posts/2024-11-14-pypi-now-supports-digital-attestations/) are enabled by default when publishing this package, but the package doesn't support them yet.