### PR TITLE
Keep the document ID when reranking

### DIFF
--- a/libs/cohere/langchain_cohere/rerank.py
+++ b/libs/cohere/langchain_cohere/rerank.py
@@ -144,7 +144,7 @@ class CohereRerank(BaseDocumentCompressor):
         compressed = []
         for res in self.rerank(documents, query):
             doc = documents[res["index"]]
-            doc_copy = Document(doc.page_content, metadata=deepcopy(doc.metadata))
+            doc_copy = Document(doc.page_content, metadata=deepcopy(doc.metadata), id=doc.id or None)
             doc_copy.metadata["relevance_score"] = res["relevance_score"]
             compressed.append(doc_copy)
         return compressed


### PR DESCRIPTION
LangChain Documents now have the Optional Field id for the BaseMedia class, which the Document class inherits.  

With this change, the id is no longer lost when reranking.