### PR TITLE
feat: add async support for rerank and compress_documents

### DIFF
--- a/libs/cohere/tests/integration_tests/cassettes/test_langchain_cohere_arerank_documents.yaml
+++ b/libs/cohere/tests/integration_tests/cassettes/test_langchain_cohere_arerank_documents.yaml
@@ -1,0 +1,72 @@
+interactions:
+- request:
+    body: '{"model": "rerank-v3.5", "query": "Test query", "documents": ["This is
+      a test document.", "Another test document."], "top_n": 3, "max_tokens_per_doc":
+      null}'
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate, zstd
+      connection:
+      - keep-alive
+      content-length:
+      - '156'
+      content-type:
+      - application/json
+      host:
+      - api.cohere.com
+      user-agent:
+      - python-httpx/0.27.2
+      x-client-name:
+      - langchain:partner
+      x-fern-language:
+      - Python
+      x-fern-sdk-name:
+      - cohere
+      x-fern-sdk-version:
+      - 5.13.11
+    method: POST
+    uri: https://api.cohere.com/v2/rerank
+  response:
+    body:
+      string: '{"id":"40560e2f-c83a-4e3c-895a-1bc926d0ebde","results":[{"index":0,"relevance_score":0.10415817},{"index":1,"relevance_score":0.0872602}],"meta":{"api_version":{"version":"2"},"billed_units":{"search_units":1}}}'
+    headers:
+      Alt-Svc:
+      - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+      Content-Length:
+      - '211'
+      Via:
+      - 1.1 google
+      access-control-expose-headers:
+      - X-Debug-Trace-ID
+      cache-control:
+      - no-cache, no-store, no-transform, must-revalidate, private, max-age=0
+      content-type:
+      - application/json
+      date:
+      - Sat, 05 Apr 2025 11:49:33 GMT
+      expires:
+      - Thu, 01 Jan 1970 00:00:00 UTC
+      pragma:
+      - no-cache
+      server:
+      - envoy
+      vary:
+      - Origin
+      x-accel-expires:
+      - '0'
+      x-debug-trace-id:
+      - 546ac4f67c17f073e5e8834ead7b85f3
+      x-endpoint-monthly-call-limit:
+      - '1000'
+      x-envoy-upstream-service-time:
+      - '52'
+      x-trial-endpoint-call-limit:
+      - '10'
+      x-trial-endpoint-call-remaining:
+      - '8'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/libs/cohere/tests/integration_tests/cassettes/test_langchain_cohere_arerank_with_rank_fields.yaml
+++ b/libs/cohere/tests/integration_tests/cassettes/test_langchain_cohere_arerank_with_rank_fields.yaml
@@ -1,0 +1,72 @@
+interactions:
+- request:
+    body: '{"model": "rerank-v3.5", "query": "penguins", "documents": ["content: This
+      document is about Penguins.\n", "content: This document is about Physics.\n"],
+      "top_n": 3, "max_tokens_per_doc": null}'
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate, zstd
+      connection:
+      - keep-alive
+      content-length:
+      - '193'
+      content-type:
+      - application/json
+      host:
+      - api.cohere.com
+      user-agent:
+      - python-httpx/0.27.2
+      x-client-name:
+      - langchain:partner
+      x-fern-language:
+      - Python
+      x-fern-sdk-name:
+      - cohere
+      x-fern-sdk-version:
+      - 5.13.11
+    method: POST
+    uri: https://api.cohere.com/v2/rerank
+  response:
+    body:
+      string: '{"id":"d6a0ac06-37ce-49fc-88d0-b6d5b8b528bf","results":[{"index":0,"relevance_score":0.54594},{"index":1,"relevance_score":0.028374104}],"meta":{"api_version":{"version":"2"},"billed_units":{"search_units":1}}}'
+    headers:
+      Alt-Svc:
+      - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+      Content-Length:
+      - '210'
+      Via:
+      - 1.1 google
+      access-control-expose-headers:
+      - X-Debug-Trace-ID
+      cache-control:
+      - no-cache, no-store, no-transform, must-revalidate, private, max-age=0
+      content-type:
+      - application/json
+      date:
+      - Sat, 05 Apr 2025 11:49:33 GMT
+      expires:
+      - Thu, 01 Jan 1970 00:00:00 UTC
+      pragma:
+      - no-cache
+      server:
+      - envoy
+      vary:
+      - Origin
+      x-accel-expires:
+      - '0'
+      x-debug-trace-id:
+      - 0ef51338c5c52e910c2f36346d1c28be
+      x-endpoint-monthly-call-limit:
+      - '1000'
+      x-envoy-upstream-service-time:
+      - '34'
+      x-trial-endpoint-call-limit:
+      - '10'
+      x-trial-endpoint-call-remaining:
+      - '7'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/libs/cohere/tests/integration_tests/cassettes/test_langchain_cohere_rerank_acompress_documents.yaml
+++ b/libs/cohere/tests/integration_tests/cassettes/test_langchain_cohere_rerank_acompress_documents.yaml
@@ -1,0 +1,72 @@
+interactions:
+- request:
+    body: '{"model": "rerank-v3.5", "query": "Test query", "documents": ["This is
+      a test document.", "Another test document."], "top_n": 3, "max_tokens_per_doc":
+      null}'
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate, zstd
+      connection:
+      - keep-alive
+      content-length:
+      - '156'
+      content-type:
+      - application/json
+      host:
+      - api.cohere.com
+      user-agent:
+      - python-httpx/0.27.2
+      x-client-name:
+      - langchain:partner
+      x-fern-language:
+      - Python
+      x-fern-sdk-name:
+      - cohere
+      x-fern-sdk-version:
+      - 5.13.11
+    method: POST
+    uri: https://api.cohere.com/v2/rerank
+  response:
+    body:
+      string: '{"id":"35dc798a-cd0a-4935-8fe4-42d27521396f","results":[{"index":0,"relevance_score":0.10415817},{"index":1,"relevance_score":0.0872602}],"meta":{"api_version":{"version":"2"},"billed_units":{"search_units":1}}}'
+    headers:
+      Alt-Svc:
+      - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+      Content-Length:
+      - '211'
+      Via:
+      - 1.1 google
+      access-control-expose-headers:
+      - X-Debug-Trace-ID
+      cache-control:
+      - no-cache, no-store, no-transform, must-revalidate, private, max-age=0
+      content-type:
+      - application/json
+      date:
+      - Sat, 05 Apr 2025 11:49:34 GMT
+      expires:
+      - Thu, 01 Jan 1970 00:00:00 UTC
+      pragma:
+      - no-cache
+      server:
+      - envoy
+      vary:
+      - Origin
+      x-accel-expires:
+      - '0'
+      x-debug-trace-id:
+      - 730e88cce24d598c1d08a0cb71860384
+      x-endpoint-monthly-call-limit:
+      - '1000'
+      x-envoy-upstream-service-time:
+      - '37'
+      x-trial-endpoint-call-limit:
+      - '10'
+      x-trial-endpoint-call-remaining:
+      - '6'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/libs/cohere/tests/integration_tests/cassettes/test_langchain_cohere_rerank_compress_documents.yaml
+++ b/libs/cohere/tests/integration_tests/cassettes/test_langchain_cohere_rerank_compress_documents.yaml
@@ -1,0 +1,72 @@
+interactions:
+- request:
+    body: '{"model": "rerank-v3.5", "query": "Test query", "documents": ["This is
+      a test document.", "Another test document."], "top_n": 3, "max_tokens_per_doc":
+      null}'
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate, zstd
+      connection:
+      - keep-alive
+      content-length:
+      - '156'
+      content-type:
+      - application/json
+      host:
+      - api.cohere.com
+      user-agent:
+      - python-httpx/0.27.2
+      x-client-name:
+      - langchain:partner
+      x-fern-language:
+      - Python
+      x-fern-sdk-name:
+      - cohere
+      x-fern-sdk-version:
+      - 5.13.11
+    method: POST
+    uri: https://api.cohere.com/v2/rerank
+  response:
+    body:
+      string: '{"id":"4df93b98-c16c-4dbe-9bfb-008fd380f322","results":[{"index":0,"relevance_score":0.10415817},{"index":1,"relevance_score":0.0872602}],"meta":{"api_version":{"version":"2"},"billed_units":{"search_units":1}}}'
+    headers:
+      Alt-Svc:
+      - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+      Content-Length:
+      - '211'
+      Via:
+      - 1.1 google
+      access-control-expose-headers:
+      - X-Debug-Trace-ID
+      cache-control:
+      - no-cache, no-store, no-transform, must-revalidate, private, max-age=0
+      content-type:
+      - application/json
+      date:
+      - Sat, 05 Apr 2025 11:49:33 GMT
+      expires:
+      - Thu, 01 Jan 1970 00:00:00 UTC
+      pragma:
+      - no-cache
+      server:
+      - envoy
+      vary:
+      - Origin
+      x-accel-expires:
+      - '0'
+      x-debug-trace-id:
+      - 6de251823d141aecf1e605ab04511185
+      x-endpoint-monthly-call-limit:
+      - '1000'
+      x-envoy-upstream-service-time:
+      - '50'
+      x-trial-endpoint-call-limit:
+      - '10'
+      x-trial-endpoint-call-remaining:
+      - '9'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/libs/cohere/tests/integration_tests/test_rerank.py
+++ b/libs/cohere/tests/integration_tests/test_rerank.py
@@ -22,7 +22,7 @@ def test_langchain_cohere_rerank_documents() -> None:
     ]
     test_query = "Test query"
     results = rerank.rerank(test_documents, test_query)
-    assert len(results) == 2
+    assert len(results) == len(test_documents)
 
 
 @pytest.mark.vcr()
@@ -40,3 +40,57 @@ def test_langchain_cohere_rerank_with_rank_fields() -> None:
     assert response[0]["index"] == 0
     results = {r["index"]: r["relevance_score"] for r in response}
     assert results[0] > results[1]
+
+
+@pytest.mark.vcr()
+def test_langchain_cohere_rerank_compress_documents() -> None:
+    rerank = CohereRerank(model="rerank-v3.5")
+    test_documents = [
+        Document(page_content="This is a test document."),
+        Document(page_content="Another test document."),
+    ]
+    test_query = "Test query"
+    results = rerank.compress_documents(test_documents, test_query)
+    assert isinstance(results[0], Document)
+    assert len(results) == len(test_documents)
+
+
+@pytest.mark.vcr()
+async def test_langchain_cohere_arerank_documents() -> None:
+    rerank = CohereRerank(model="rerank-v3.5")
+    test_documents = [
+        Document(page_content="This is a test document."),
+        Document(page_content="Another test document."),
+    ]
+    test_query = "Test query"
+    results = await rerank.arerank(test_documents, test_query)
+    assert len(results) == len(test_documents)
+
+
+@pytest.mark.vcr()
+async def test_langchain_cohere_arerank_with_rank_fields() -> None:
+    rerank = CohereRerank(model="rerank-v3.5")
+    test_documents = [
+        {"content": "This document is about Penguins.", "subject": "Physics"},
+        {"content": "This document is about Physics.", "subject": "Penguins"},
+    ]
+    test_query = "penguins"
+
+    response = await rerank.arerank(test_documents, test_query, rank_fields=["content"])
+    assert len(response) == 2
+    assert response[0]["index"] == 0
+    results = {r["index"]: r["relevance_score"] for r in response}
+    assert results[0] > results[1]
+
+
+@pytest.mark.vcr()
+async def test_langchain_cohere_rerank_acompress_documents() -> None:
+    rerank = CohereRerank(model="rerank-v3.5")
+    test_documents = [
+        Document(page_content="This is a test document."),
+        Document(page_content="Another test document."),
+    ]
+    test_query = "Test query"
+    results = await rerank.acompress_documents(test_documents, test_query)
+    assert isinstance(results[0],Document)
+    assert len(results) == len(test_documents)


### PR DESCRIPTION
- Added method for asynchronous (`arerank`) reranking of documents using Cohere's API.
- Included `_document_to_str_async` helper methods for document serialization with async manner.
- Added `acompress_documents` methods to asynchronously compress documents.

