### PR TITLE
add: embed images

### DIFF
--- a/libs/cohere/langchain_cohere/embeddings.py
+++ b/libs/cohere/langchain_cohere/embeddings.py
@@ -133,15 +133,17 @@ class CohereEmbeddings(BaseModel, Embeddings):
 
         return _embed_with_retry(**kwargs)
 
-    def embed(
+    def _embed_generic(
         self,
-        texts: List[str],
+        texts: typing.Optional[List[str]] = None,
+        images: typing.Optional[List[str]] = None,
         *,
         input_type: typing.Optional[cohere.EmbedInputType] = None,
     ) -> List[List[float]]:
         response = self.embed_with_retry(
             model=self.model,
             texts=texts,
+            images=images,
             input_type=input_type,
             truncate=self.truncate,
             embedding_types=self.embedding_types,
@@ -156,15 +158,17 @@ class CohereEmbeddings(BaseModel, Embeddings):
                 embeddings_as_float.append(list(map(float, e[i])))
         return embeddings_as_float
 
-    async def aembed(
+    async def _aembed_generic(
         self,
-        texts: List[str],
+        texts: typing.Optional[List[str]] = None,
+        images: typing.Optional[List[str]] = None,
         *,
         input_type: typing.Optional[cohere.EmbedInputType] = None,
     ) -> List[List[float]]:
         response = await self.aembed_with_retry(
             model=self.model,
             texts=texts,
+            images=images,
             input_type=input_type,
             truncate=self.truncate,
             embedding_types=self.embedding_types,
@@ -178,6 +182,22 @@ class CohereEmbeddings(BaseModel, Embeddings):
             for i in range(len(e)):
                 embeddings_as_float.append(list(map(float, e[i])))
         return embeddings_as_float
+
+    def embed(
+        self,
+        texts: List[str],
+        *,
+        input_type: typing.Optional[cohere.EmbedInputType] = None,
+    ) -> List[List[float]]:
+        return self._embed_generic(texts=texts, input_type=input_type)
+
+    async def aembed(
+        self,
+        texts: List[str],
+        *,
+        input_type: typing.Optional[cohere.EmbedInputType] = None,
+    ) -> List[List[float]]:
+        return await self._aembed_generic(texts=texts, input_type=input_type)
 
     def embed_documents(self, texts: List[str]) -> List[List[float]]:
         """Embed a list of document texts.
@@ -222,3 +242,25 @@ class CohereEmbeddings(BaseModel, Embeddings):
             Embeddings for the text.
         """
         return (await self.aembed([text], input_type="search_query"))[0]
+
+    def embed_images(self, images: List[str]) -> List[List[float]]:
+        """Call out to Cohere's embedding endpoint for images.
+
+        Args:
+            images: The list of images to embed.
+
+        Returns:
+            List of embeddings, one for each image.
+        """
+        return self._embed_generic(images=images, input_type="image")
+
+    async def aembed_images(self, images: List[str]) -> List[List[float]]:
+        """Async call out to Cohere's embedding endpoint for images.
+
+        Args:
+            images: The list of images to embed.
+
+        Returns:
+            List of embeddings, one for each image.
+        """
+        return await self._aembed_generic(images=images, input_type="image")

--- a/libs/cohere/tests/integration_tests/test_embeddings.py
+++ b/libs/cohere/tests/integration_tests/test_embeddings.py
@@ -106,3 +106,73 @@ async def test_langchain_cohere_aembedding_documents_int8_embedding_type() -> No
     output = await embedding.aembed_documents(documents)
     assert len(output) == 1
     assert len(output[0]) > 0
+
+
+@pytest.mark.vcr()
+def test_langchain_cohere_embedding_images() -> None:
+    images = [
+        "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII="
+    ]
+    embedding = CohereEmbeddings(model="embed-v4.0")
+    output = embedding.embed_images(images)
+    assert len(output) == 1
+    assert len(output[0]) > 0
+
+
+@pytest.mark.vcr()
+def test_langchain_cohere_embedding_multiple_images() -> None:
+    images = [
+        "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=",
+        "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=",
+    ]
+    embedding = CohereEmbeddings(model="embed-v4.0")
+    output = embedding.embed_images(images)
+    assert len(output) == 2
+    assert len(output[0]) > 0
+    assert len(output[1]) > 0
+
+
+@pytest.mark.vcr()
+def test_langchain_cohere_embedding_images_int8_embedding_type() -> None:
+    images = [
+        "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII="
+    ]
+    embedding = CohereEmbeddings(model="embed-v4.0", embedding_types=["int8"])
+    output = embedding.embed_images(images)
+    assert len(output) == 1
+    assert len(output[0]) > 0
+
+
+@pytest.mark.vcr()
+async def test_langchain_cohere_aembedding_images() -> None:
+    images = [
+        "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII="
+    ]
+    embedding = CohereEmbeddings(model="embed-v4.0")
+    output = await embedding.aembed_images(images)
+    assert len(output) == 1
+    assert len(output[0]) > 0
+
+
+@pytest.mark.vcr()
+async def test_langchain_cohere_aembedding_multiple_images() -> None:
+    images = [
+        "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=",
+        "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=",
+    ]
+    embedding = CohereEmbeddings(model="embed-v4.0")
+    output = await embedding.aembed_images(images)
+    assert len(output) == 2
+    assert len(output[0]) > 0
+    assert len(output[1]) > 0
+
+
+@pytest.mark.vcr()
+async def test_langchain_cohere_aembedding_images_int8_embedding_type() -> None:
+    images = [
+        "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII="
+    ]
+    embedding = CohereEmbeddings(model="embed-v4.0", embedding_types=["int8"])
+    output = await embedding.aembed_images(images)
+    assert len(output) == 1
+    assert len(output[0]) > 0


### PR DESCRIPTION
This PR adds support for image embedding for any Cohere model that accepts `input_type="image"`.

**What's included:**
- Introduced `embed_images()` and `aembed_images()` methods for handling image inputs.
- Added internal `_embed_generic()` and `_aembed_generic()` methods to abstract over text/image input types.
- Added a test case that confirms image embedding works with supported models.