### PR TITLE
Allow rerank kwargs on compress

### DIFF
--- a/libs/cohere/langchain_cohere/rerank.py
+++ b/libs/cohere/langchain_cohere/rerank.py
@@ -135,6 +135,7 @@ class CohereRerank(BaseDocumentCompressor):
         documents: Sequence[Document],
         query: str,
         callbacks: Optional[Callbacks] = None,
+        **kwargs: Any,
     ) -> Sequence[Document]:
         """
         Compress documents using Cohere's rerank API.
@@ -143,12 +144,13 @@ class CohereRerank(BaseDocumentCompressor):
             documents: A sequence of documents to compress.
             query: The query to use for compressing the documents.
             callbacks: Callbacks to run during the compression process.
+            **kwargs: Additional arguments to pass to the rerank method.
 
         Returns:
             A sequence of compressed documents.
         """
         compressed = []
-        for res in self.rerank(documents, query):
+        for res in self.rerank(documents, query, **kwargs):
             doc = documents[res["index"]]
             doc_copy = Document(doc.page_content, metadata=deepcopy(doc.metadata))
             doc_copy.metadata["relevance_score"] = res["relevance_score"]


### PR DESCRIPTION
AWS Bedrock Cohere requires `max_tokens_per_doc` on the rerank call- cannot be Null. `self.rerank` allows configuration of it, but it doesn't make it to `compress_document function`. This allows kwargs to be passed to rerank to allow that.