### PR TITLE
Adjust `cohere` version upper bound to 5.16 (excluding) to prevent incompatibility errors

### DIFF
--- a/libs/cohere/pyproject.toml
+++ b/libs/cohere/pyproject.toml
@@ -13,7 +13,9 @@ license = "MIT"
 [tool.poetry.dependencies]
 python = ">=3.9,<4.0"
 langchain-core = "^0.3.27"
-cohere = ">=5.12.0,<6.0"
+# Pin cohere to <5.16 to prevent breakage as cohere 5.16.0 removes ChatResponse
+# TODO: remove cohere pin when langchain_cohere is updated to work with cohere >=5.16
+cohere = ">=5.12.0,<5.16"
 langchain-community = { version = "^0.3.0"}
 pydantic = ">=2,<3"
 types-pyyaml = "^6.0.12.20240917"


### PR DESCRIPTION
### References 

Fixes #140.

### Problem 

`cohere` 5.16 removed `ChatResponse` class that `langchain_cohere` depends on. As of now `langchain_cohere` have `cohere` pinned as `cohere = ">=5.12.0,<6.0"` ([link](https://github.com/langchain-ai/langchain-cohere/blob/8d78a17ba365cefa67996962316d4c13d39567d5/libs/cohere/pyproject.toml#L16C1-L16C25)) so will pull in all new 5.x.y versions automatically. 

### Proposed solution

Change upper bound to `<5.16` which would solve the issue in short-term. Long-term update to account for breaking changes seems to be required but it's out of scope of this PR.