### PR TITLE
fix: replace deprecated ChatResponse import with V2ChatResponse alias…

### DIFF
--- a/libs/cohere/langchain_cohere/chat_models.py
+++ b/libs/cohere/langchain_cohere/chat_models.py
@@ -19,7 +19,6 @@ from typing import (
 from cohere import (
     AssistantChatMessageV2,
     ChatMessageV2,
-    ChatResponse,
     DocumentToolContent,
     NonStreamedChatResponse,
     SystemChatMessageV2,
@@ -30,6 +29,9 @@ from cohere import (
     UserChatMessageV2,
 )
 from cohere import Document as DocumentV2
+from cohere import (
+    V2ChatResponse as ChatResponse,
+)
 from langchain_core._api.deprecation import warn_deprecated
 from langchain_core.callbacks import (
     AsyncCallbackManagerForLLMRun,

--- a/libs/cohere/tests/unit_tests/test_chat_models.py
+++ b/libs/cohere/tests/unit_tests/test_chat_models.py
@@ -8,7 +8,6 @@ from cohere import (
     AssistantChatMessageV2,
     AssistantMessageResponse,
     ChatMessageEndEventDelta,
-    ChatResponse,
     NonStreamedChatResponse,
     SystemChatMessageV2,
     ToolCall,
@@ -21,6 +20,9 @@ from cohere import (
     UsageBilledUnits,
     UsageTokens,
     UserChatMessageV2,
+)
+from cohere import (
+    V2ChatResponse as ChatResponse,
 )
 from langchain_core.documents import Document
 from langchain_core.messages import AIMessage, BaseMessage, HumanMessage, ToolMessage


### PR DESCRIPTION
This PR addresses issue #146 by replacing the import of the deprecated `ChatResponse` type with `V2ChatResponse` aliased as `ChatResponse`.
This change ensures compatibility with Cohere SDK versions >= 5.0, where `ChatResponse` is no longer exposed directly.

All references remain as `ChatResponse` to minimize downstream impact while aligning with the updated SDK structure.
