### PR TITLE
fix: ChatCohere._agenerate tool call parsing broken 

### DIFF
--- a/libs/cohere/langchain_cohere/chat_models.py
+++ b/libs/cohere/langchain_cohere/chat_models.py
@@ -1197,7 +1197,7 @@ class ChatCohere(BaseChatModel, BaseCohere):
             content = response.message.tool_plan if response.message.tool_plan else ""
             tool_calls = [
                 lc_tool_call
-                for tool_call in response.tool_calls
+                for tool_call in response.message.tool_calls
                 if (
                     lc_tool_call := _convert_cohere_v2_tool_call_to_langchain(tool_call)
                 )


### PR DESCRIPTION
### Description

Fix tool_calls improperly located in model response for `ChatCohere._agenerate`:

```python
@tool()
def multiply(a: int, b: int) -> int:
    """Multiply two numbers"""
    return a * b

cohere_llm = ChatCohere(model="command-r-plus")
agent = create_react_agent(cohere_llm, [multiply])
resp = await agent.ainvoke({"messages": [{"role": "user", "content": "what's 127891 * 12089?"}]})
```
```
AttributeError: 'V2ChatResponse' object has no attribute 'tool_calls'
```
### Issues
Resolves langchain-ai/langgraph#6138
