### PR TITLE
feat: add OpenAI-style tool_choice translation in bind_tools()

### DIFF
--- a/libs/cohere/tests/unit_tests/test_chat_models.py
+++ b/libs/cohere/tests/unit_tests/test_chat_models.py
@@ -1372,3 +1372,43 @@ def test_get_cohere_chat_request_v2_warn_connectors_deprecated(
         warning.message
     )
     assert "Please use the 'tools' parameter instead." in str(warning.message)
+
+
+@pytest.mark.parametrize(
+    "tool_choice_input,expected_tool_choice",
+    [
+        pytest.param("any", "REQUIRED", id="any -> REQUIRED"),
+        pytest.param("ANY", "REQUIRED", id="ANY -> REQUIRED"),
+        pytest.param("none", "NONE", id="none -> NONE"),
+        pytest.param("NONE", "NONE", id="NONE -> NONE"),
+        pytest.param("auto", None, id="auto -> removed"),
+        pytest.param("AUTO", None, id="AUTO -> removed"),
+        pytest.param("REQUIRED", "REQUIRED", id="REQUIRED -> REQUIRED (unchanged)"),
+        pytest.param(None, None, id="None -> None (no tool_choice)"),
+    ],
+)
+def test_bind_tools_tool_choice_translation(
+    patch_base_cohere_get_default_model: Generator[Optional[BaseCohere], None, None],
+    tool_choice_input: Optional[str],
+    expected_tool_choice: Optional[str],
+) -> None:
+    """Test that bind_tools() translates OpenAI-style tool_choice to Cohere format."""
+
+    @tool
+    def test_tool(x: int) -> int:
+        """Test tool."""
+        return x + 1
+
+    chat = ChatCohere(cohere_api_key="test")
+
+    # Bind tools with tool_choice
+    if tool_choice_input is not None:
+        bound = chat.bind_tools([test_tool], tool_choice=tool_choice_input)
+    else:
+        bound = chat.bind_tools([test_tool])
+
+    # Check the bound kwargs
+    if expected_tool_choice is not None:
+        assert bound.kwargs.get("tool_choice") == expected_tool_choice
+    else:
+        assert "tool_choice" not in bound.kwargs


### PR DESCRIPTION
## Description

This PR adds support for OpenAI-style `tool_choice` parameter translation in the `bind_tools()` method, resolving compatibility issues when using Cohere models with cross-provider code.

## Problem

Currently, when using `create_agent()` from `langchain_v1` with Cohere models and `response_format` (which internally uses `tool_choice="any"`), it fails with a 422 error because Cohere expects `"REQUIRED"` instead of `"any"`.

Reference: https://github.com/langchain-ai/langchain-cohere/issues/161

## Solution

Modified `ChatCohere.bind_tools()` to automatically translate OpenAI-style tool_choice values:

- `"any"` → `"REQUIRED"` (force tool use)
- `"none"` → `"NONE"` (prevent tool use)
- `"auto"` → removed (default behavior - let model decide)
- Existing Cohere values (`"REQUIRED"`, `"NONE"`) pass through unchanged
- Case-insensitive matching

## Changes

1. **chat_models.py**: Updated `bind_tools()` method with translation logic and docstring
2. **test_chat_models.py**: Added comprehensive parametrized tests covering all translation scenarios

## Testing

Added 8 test cases covering:
- ✅ `"any"` / `"ANY"` → `"REQUIRED"`
- ✅ `"none"` / `"NONE"` → `"NONE"` 
- ✅ `"auto"` / `"AUTO"` → removed
- ✅ `"REQUIRED"` → unchanged
- ✅ `None` → no tool_choice parameter

## Backward Compatibility

✅ **Fully backward compatible**
- Existing code using Cohere-style values continues to work unchanged
- Only adds translation for OpenAI-style values
- Does not modify any existing behavior

## Impact

- ✅ Unblocks Cohere users from using `create_agent()` with `response_format`
- ✅ Improves cross-provider compatibility
- ✅ No breaking changes

## Related Issues

- Closes langchain-ai/langchain-cohere#161