### PR TITLE
Fix grammar: add missing 'of' after 'favour'

### DIFF
--- a/libs/cohere/README.md
+++ b/libs/cohere/README.md
@@ -14,7 +14,7 @@ pip install langchain-cohere
 
 ## Migration from langchain-community
 
-Cohere's integrations used to be part of the `langchain-community` package, but since version 0.0.30 the integration in `langchain-community` has been deprecated in favour `langchain-cohere`.
+Cohere's integrations used to be part of the `langchain-community` package, but since version 0.0.30 the integration in `langchain-community` has been deprecated in favour of `langchain-cohere`.
 
 The two steps to migrate are:
 


### PR DESCRIPTION
Corrects grammar in README where 'in favour' should be 'in favour of'.