### PR TITLE
Add Command A Vision support

### DIFF
--- a/libs/cohere/README.md
+++ b/libs/cohere/README.md
@@ -52,6 +52,68 @@ messages = [HumanMessage(content="Hello, can you introduce yourself?")]
 print(llm.invoke(messages))
 ```
 
+### Vision (Image Inputs)
+
+Command A Vision models can process images alongside text. Supports both URL and base64-encoded images.
+
+```python
+from langchain_cohere import ChatCohere
+from langchain_core.messages import HumanMessage
+
+# Initialize the vision model
+llm = ChatCohere(model="command-a-vision-07-2025")
+
+# Using an image URL
+message = HumanMessage(
+    content=[
+        {"type": "text", "text": "What's in this image?"},
+        {
+            "type": "image_url",
+            "image_url": {"url": "https://example.com/image.jpg"}
+        }
+    ]
+)
+response = llm.invoke([message])
+print(response.content)
+
+# Using a base64-encoded image with detail level
+message = HumanMessage(
+    content=[
+        {"type": "text", "text": "Describe this chart in detail"},
+        {
+            "type": "image_url",
+            "image_url": {
+                "url": "data:image/png;base64,iVBORw0KG...",
+                "detail": "high"  # Options: "low", "high", or "auto" (default)
+            }
+        }
+    ]
+)
+response = llm.invoke([message])
+print(response.content)
+
+# Multiple images
+message = HumanMessage(
+    content=[
+        {"type": "text", "text": "Compare these images"},
+        {"type": "image_url", "image_url": {"url": "https://example.com/image1.jpg"}},
+        {"type": "image_url", "image_url": {"url": "https://example.com/image2.jpg"}}
+    ]
+)
+response = llm.invoke([message])
+print(response.content)
+```
+
+**Image Requirements:**
+- Maximum 20 images per request or 20MB total
+- Supported formats: PNG, JPEG, WEBP, non-animated GIF
+- Detail levels affect token usage:
+  - `"low"`: 256 tokens per image (faster, lower cost)
+  - `"high"`: More tokens based on image size (better quality)
+  - `"auto"`: Automatically selects appropriate detail level
+
+For more information, see [Cohere's Vision documentation](https://docs.cohere.com/docs/image-inputs).
+
 ### ReAct Agent
 
 ```python

--- a/libs/cohere/examples/vision_example.py
+++ b/libs/cohere/examples/vision_example.py
@@ -1,0 +1,52 @@
+"""
+Quick smoke test for Command A Vision support.
+
+Usage:
+    export COHERE_API_KEY=your-key
+    python libs/cohere/examples/vision_example.py
+    python libs/cohere/examples/vision_example.py --image https://your-image-url.jpg
+"""
+
+import argparse
+
+from langchain_cohere import ChatCohere
+from langchain_core.messages import HumanMessage
+
+DEFAULT_IMAGE_URL = "https://cohere.com/favicon-32x32.png"
+VISION_MODEL = "command-a-vision-07-2025"
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Test Command A Vision via langchain-cohere")
+    parser.add_argument(
+        "--image",
+        default=DEFAULT_IMAGE_URL,
+        help="Image URL or data URI (base64) to send to the model",
+    )
+    parser.add_argument(
+        "--prompt",
+        default="What's in this image?",
+        help="Text prompt to accompany the image",
+    )
+    args = parser.parse_args()
+
+    llm = ChatCohere(model=VISION_MODEL)
+
+    message = HumanMessage(
+        content=[
+            {"type": "text", "text": args.prompt},
+            {"type": "image_url", "image_url": {"url": args.image}},
+        ]
+    )
+
+    print(f"Model:  {VISION_MODEL}")
+    print(f"Image:  {args.image[:80]}{'...' if len(args.image) > 80 else ''}")
+    print(f"Prompt: {args.prompt}")
+    print("-" * 60)
+
+    response = llm.invoke([message])
+    print(response.content)
+
+
+if __name__ == "__main__":
+    main()

--- a/libs/cohere/examples/vision_example.py
+++ b/libs/cohere/examples/vision_example.py
@@ -9,15 +9,18 @@ Usage:
 
 import argparse
 
-from langchain_cohere import ChatCohere
 from langchain_core.messages import HumanMessage
+
+from langchain_cohere import ChatCohere
 
 DEFAULT_IMAGE_URL = "https://cohere.com/favicon-32x32.png"
 VISION_MODEL = "command-a-vision-07-2025"
 
 
 def main() -> None:
-    parser = argparse.ArgumentParser(description="Test Command A Vision via langchain-cohere")
+    parser = argparse.ArgumentParser(
+        description="Test Command A Vision via langchain-cohere"
+    )
     parser.add_argument(
         "--image",
         default=DEFAULT_IMAGE_URL,

--- a/libs/cohere/langchain_cohere/chat_models.py
+++ b/libs/cohere/langchain_cohere/chat_models.py
@@ -21,8 +21,10 @@ from cohere import (
     ChatMessageV2,
     ChatResponse,
     DocumentToolContent,
+    ImageUrlContent,
     NonStreamedChatResponse,
     SystemChatMessageV2,
+    TextContent,
     ToolCall,
     ToolCallV2,
     ToolCallV2Function,
@@ -429,7 +431,7 @@ def _get_message_cohere_format_v2(
     elif isinstance(message, HumanMessage):
         return UserChatMessageV2(
             role=get_role_v2(message),
-            content=message.content,
+            content=_convert_content_to_cohere_format(message.content),
         )
     elif isinstance(message, SystemMessage):
         return SystemChatMessageV2(
@@ -464,6 +466,50 @@ def _get_message_cohere_format_v2(
         )
     else:
         raise ValueError(f"Got unknown type {message}")
+
+
+def _convert_content_to_cohere_format(
+    content: Union[str, List[Union[str, Dict[str, Any]]]],
+) -> Union[str, List[Union[TextContent, ImageUrlContent]]]:
+    """Convert LangChain message content to Cohere format.
+
+    Args:
+        content: Either a string or a list of content items (text and/or images)
+
+    Returns:
+        Either a string (for text-only) or a list of TextContent/ImageUrlContent objects
+    """
+    if isinstance(content, str):
+        return content
+
+    if not isinstance(content, list):
+        return str(content)
+
+    cohere_content: List[Union[TextContent, ImageUrlContent]] = []
+
+    for item in content:
+        if isinstance(item, str):
+            cohere_content.append(TextContent(type="text", text=item))
+        elif isinstance(item, dict):
+            content_type = item.get("type")
+
+            if content_type == TextContent.model_fields["type"].default:
+                text = item.get("text", "")
+                cohere_content.append(TextContent(type="text", text=text))
+            elif content_type == ImageUrlContent.model_fields["type"].default:
+                image_url_data = item.get("image_url", {})
+                if isinstance(image_url_data, str):
+                    cohere_content.append(
+                        ImageUrlContent(
+                            type="image_url", image_url={"url": image_url_data}
+                        )
+                    )
+                elif isinstance(image_url_data, dict):
+                    cohere_content.append(
+                        ImageUrlContent(type="image_url", image_url=image_url_data)
+                    )
+
+    return cohere_content if cohere_content else ""
 
 
 def get_cohere_chat_request_v2(

--- a/libs/cohere/tests/integration_tests/cassettes/test_astream_with_vision.yaml
+++ b/libs/cohere/tests/integration_tests/cassettes/test_astream_with_vision.yaml
@@ -1,0 +1,876 @@
+interactions:
+- request:
+    body: '{"model":"command-a-vision-07-2025","messages":[{"role":"user","content":[{"type":"text","text":"What''s
+      in this image?"},{"type":"image_url","image_url":{"url":"https://cohere.com/favicon-32x32.png"}}]}],"stream":true}'
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate, zstd
+      connection:
+      - keep-alive
+      content-length:
+      - '218'
+      content-type:
+      - application/json
+      host:
+      - api.cohere.com
+      user-agent:
+      - cohere/5.18.0
+      x-client-name:
+      - langchain:partner
+      x-fern-language:
+      - Python
+      x-fern-sdk-name:
+      - cohere
+      x-fern-sdk-version:
+      - 5.18.0
+    method: POST
+    uri: https://api.cohere.com/v2/chat
+  response:
+    body:
+      string: 'event: message-start
+
+        data: {"id":"5bbdb185-19bf-4683-bdbc-7e21f2dead78","type":"message-start","delta":{"message":{"role":"assistant","content":[],"tool_plan":"","tool_calls":[],"citations":[]}}}
+
+
+        event: content-start
+
+        data: {"type":"content-start","index":0,"delta":{"message":{"content":{"type":"text","text":""}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"The"}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"
+        image"}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"
+        you"}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"''ve"}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"
+        provided"}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"
+        is"}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"
+        quite"}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"
+        blurry"}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":","}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"
+        making"}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"
+        it"}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"
+        difficult"}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"
+        to"}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"
+        discern"}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"
+        specific"}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"
+        details"}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"."}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"
+        However"}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":","}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"
+        I"}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"
+        can"}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"
+        see"}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"
+        three"}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"
+        distinct"}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"
+        colored"}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"
+        shapes"}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":":"}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"\n\n1"}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"."}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"
+        A"}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"
+        large"}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"
+        green"}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"
+        shape"}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"
+        at"}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"
+        the"}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"
+        top"}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":","}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"
+        which"}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"
+        appears"}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"
+        to"}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"
+        be"}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"
+        an"}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"
+        oval"}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"
+        or"}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"
+        a"}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"
+        rounded"}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"
+        rectangle"}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"."}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"\n2"}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"."}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"
+        A"}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"
+        smaller"}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"
+        orange"}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"
+        shape"}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"
+        below"}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"
+        the"}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"
+        green"}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"
+        one"}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":","}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"
+        which"}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"
+        seems"}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"
+        to"}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"
+        be"}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"
+        a"}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"
+        circle"}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"."}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"\n3"}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"."}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"
+        A"}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"
+        purple"}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"
+        shape"}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"
+        to"}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"
+        the"}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"
+        right"}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"
+        of"}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"
+        the"}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"
+        orange"}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"
+        one"}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":","}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"
+        which"}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"
+        also"}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"
+        appears"}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"
+        to"}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"
+        be"}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"
+        an"}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"
+        oval"}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"
+        or"}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"
+        a"}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"
+        rounded"}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"
+        rectangle"}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"."}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"\n\nThese"}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"
+        shapes"}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"
+        are"}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"
+        set"}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"
+        against"}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"
+        a"}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"
+        white"}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"
+        background"}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"."}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"
+        Due"}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"
+        to"}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"
+        the"}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"
+        bl"}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"urr"}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"iness"}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":","}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"
+        I"}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"
+        can"}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"''t"}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"
+        provide"}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"
+        more"}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"
+        detailed"}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"
+        information"}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"
+        about"}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"
+        the"}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"
+        image"}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"."}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"
+        If"}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"
+        you"}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"
+        have"}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"
+        a"}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"
+        clearer"}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"
+        version"}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"
+        or"}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"
+        more"}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"
+        context"}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":","}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"
+        I"}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"''d"}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"
+        be"}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"
+        happy"}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"
+        to"}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"
+        help"}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"
+        further"}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"!"}}}}
+
+
+        event: content-end
+
+        data: {"type":"content-end","index":0}
+
+
+        event: message-end
+
+        data: {"type":"message-end","delta":{"finish_reason":"COMPLETE","usage":{"billed_units":{"input_tokens":265,"output_tokens":141},"tokens":{"input_tokens":502,"output_tokens":141,"image_tokens":259},"cached_tokens":480}}}
+
+
+        data: [DONE]
+
+
+        '
+    headers:
+      Alt-Svc:
+      - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+      Transfer-Encoding:
+      - chunked
+      Via:
+      - 1.1 google
+      access-control-expose-headers:
+      - X-Debug-Trace-ID
+      cache-control:
+      - no-cache, no-store, no-transform, must-revalidate, private, max-age=0
+      content-type:
+      - text/event-stream
+      date:
+      - Tue, 03 Feb 2026 03:41:22 GMT
+      expires:
+      - Thu, 01 Jan 1970 00:00:00 GMT
+      pragma:
+      - no-cache
+      server:
+      - envoy
+      vary:
+      - Origin
+      x-accel-expires:
+      - '0'
+      x-debug-trace-id:
+      - 944a20f1b66d85309c6a052c79e9b52e
+      x-envoy-upstream-service-time:
+      - '680'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/libs/cohere/tests/integration_tests/cassettes/test_invoke_with_multiple_images.yaml
+++ b/libs/cohere/tests/integration_tests/cassettes/test_invoke_with_multiple_images.yaml
@@ -1,0 +1,78 @@
+interactions:
+- request:
+    body: '{"model":"command-a-vision-07-2025","messages":[{"role":"user","content":[{"type":"text","text":"Compare
+      these two images"},{"type":"image_url","image_url":{"url":"https://cohere.com/favicon-32x32.png"}},{"type":"image_url","image_url":{"url":"https://cohere.com/favicon-32x32.png","detail":"low"}}]}],"stream":false}'
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate, zstd
+      connection:
+      - keep-alive
+      content-length:
+      - '317'
+      content-type:
+      - application/json
+      host:
+      - api.cohere.com
+      user-agent:
+      - cohere/5.18.0
+      x-client-name:
+      - langchain:partner
+      x-fern-language:
+      - Python
+      x-fern-sdk-name:
+      - cohere
+      x-fern-sdk-version:
+      - 5.18.0
+    method: POST
+    uri: https://api.cohere.com/v2/chat
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAA/2yRwW7bMAyGX4XjJRelSIM4yXwdegiwYT3sNgyBLDE1UVk0RDqdEfjdB6dNV2A7
+        CfxJ4vskXZAj1rj+vNlX+9VmGatds9zE6JdN0zTLbVXtt6tdtd5VK3TYkap/IqwvWCQR1uhVWc1n
+        Q4dBslE2rH9e0MZ+bhv9njvXo8bDogOVUkYHzWBwgODzwqAvcuZI4CFI1/vCKhnkBNYS2IsAd/6J
+        FLzOyQi+EGQxOLNykwg4gwwFguQzFfXGku/gcIJRBmj9mUB7CnziAJHMc1KQApE0FO7nYb2x3jij
+        DIsIiZ8JTN6UyL3aQqBinnMaoaXUwwtbC9Z6+wSPibzS+2U6KbPaSUp3VQLfyGAfOA58jnBYpARR
+        oBuhIbWZ+Pqks8YdTr8mhyfOrO2xkFfJWOOX798evz78eECHw+07Gk6J4nHIbDrXnPvBjibPlBXr
+        ar12KIN9zLbV5PBW/LOwuv/PgsOr+t+p+/3kMPjQUnwPN/vVNP0JAAD//0jwz59XAgAA
+    headers:
+      Alt-Svc:
+      - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+      Transfer-Encoding:
+      - chunked
+      Via:
+      - 1.1 google
+      access-control-expose-headers:
+      - X-Debug-Trace-ID
+      cache-control:
+      - no-cache, no-store, no-transform, must-revalidate, private, max-age=0
+      content-encoding:
+      - gzip
+      content-type:
+      - application/json
+      date:
+      - Tue, 03 Feb 2026 04:11:13 GMT
+      expires:
+      - Thu, 01 Jan 1970 00:00:00 GMT
+      num_chars:
+      - '2628'
+      num_tokens:
+      - '587'
+      pragma:
+      - no-cache
+      server:
+      - envoy
+      vary:
+      - Origin,Accept-Encoding
+      x-accel-expires:
+      - '0'
+      x-debug-trace-id:
+      - 7168ed8e1bb94a229528a97d83e79ce2
+      x-envoy-upstream-service-time:
+      - '2048'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/libs/cohere/tests/integration_tests/cassettes/test_invoke_with_text_only_list.yaml
+++ b/libs/cohere/tests/integration_tests/cassettes/test_invoke_with_text_only_list.yaml
@@ -1,0 +1,77 @@
+interactions:
+- request:
+    body: '{"model":"command-a-vision-07-2025","messages":[{"role":"user","content":[{"type":"text","text":"Hello,
+      "},{"type":"text","text":"how are you?"}]}],"stream":false}'
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate, zstd
+      connection:
+      - keep-alive
+      content-length:
+      - '163'
+      content-type:
+      - application/json
+      host:
+      - api.cohere.com
+      user-agent:
+      - cohere/5.18.0
+      x-client-name:
+      - langchain:partner
+      x-fern-language:
+      - Python
+      x-fern-sdk-name:
+      - cohere
+      x-fern-sdk-version:
+      - 5.18.0
+    method: POST
+    uri: https://api.cohere.com/v2/chat
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAA/2yPwWrjQAyGX0Wry17skMQJG89lD0sggS3tobdSgmLLnsGTmdSSm5rgdy92SSml
+        J/H/3yeEruhKNLhZULEs5lWa55Snq2qRpfkxp7T8s8iO+brKsmWGCZ5YhGpGc8U2ekaDJOJEKSgm
+        WMSgHBTN0xW1P49Y+W0k0zC4Y+8jqOWWf8H+9wnK6EINF/Y+AbUUGuhjB1VsgaRxoZ5N1uiDRvi4
+        NSkXpxYo9PDSsaiLQSC2oCSNTPzkaqtg6ZVnsIsXKCjAHiz784Q1ltT/xeF5SLBywYk9tEwSAxr8
+        d3/38H/7uMUEu9uzR+c9l4cuOJUxu3Du9KCx4SBoNgnGTr822XpI8Ba+6+t59vNCQYXl8rNbbebD
+        8B4AAP//fZJP3qABAAA=
+    headers:
+      Alt-Svc:
+      - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+      Transfer-Encoding:
+      - chunked
+      Via:
+      - 1.1 google
+      access-control-expose-headers:
+      - X-Debug-Trace-ID
+      cache-control:
+      - no-cache, no-store, no-transform, must-revalidate, private, max-age=0
+      content-encoding:
+      - gzip
+      content-type:
+      - application/json
+      date:
+      - Tue, 03 Feb 2026 03:41:31 GMT
+      expires:
+      - Thu, 01 Jan 1970 00:00:00 GMT
+      num_chars:
+      - '2598'
+      num_tokens:
+      - '43'
+      pragma:
+      - no-cache
+      server:
+      - envoy
+      vary:
+      - Origin,Accept-Encoding
+      x-accel-expires:
+      - '0'
+      x-debug-trace-id:
+      - 2b487a3beeae368190fa8861de3ddd43
+      x-envoy-upstream-service-time:
+      - '832'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/libs/cohere/tests/integration_tests/cassettes/test_invoke_with_vision_base64.yaml
+++ b/libs/cohere/tests/integration_tests/cassettes/test_invoke_with_vision_base64.yaml
@@ -1,0 +1,78 @@
+interactions:
+- request:
+    body: '{"model":"command-a-vision-07-2025","messages":[{"role":"user","content":[{"type":"text","text":"Describe
+      this image"},{"type":"image_url","image_url":{"url":"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8DwHwAFBQIAX8jx0gAAAABJRU5ErkJggg==","detail":"high"}}]}],"stream":false}'
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate, zstd
+      connection:
+      - keep-alive
+      content-length:
+      - '315'
+      content-type:
+      - application/json
+      host:
+      - api.cohere.com
+      user-agent:
+      - cohere/5.18.0
+      x-client-name:
+      - langchain:partner
+      x-fern-language:
+      - Python
+      x-fern-sdk-name:
+      - cohere
+      x-fern-sdk-version:
+      - 5.18.0
+    method: POST
+    uri: https://api.cohere.com/v2/chat
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAA/2yQQW/bPAyG/wo/XnpRin5J2ji+Dj0M2LAdchuGQJaomKssuSKVLQj83wcbDToM
+        OwkU8Tx8ySuyxxabR7exYbdfbUOzW2137mHVPK3Xq6ZxTfi/C26zcWhwIBF7ImyvWHIkbNGKsKhN
+        igZdTkpJsf12Rb2Mc1vp19xZnhYPPQEP9kRwyfXuTDCWfGZPHljAguTIHgp5kNdqC93DoadCYAtB
+        yuBZHJXEXSTI3Q9yKgZms4FcIGtPBSjSQEkFfrL2nEBvE+/ho94JCA9jvICFmjjkMizTXI65QOAY
+        OZ0WhJJyobcYEIodZkGYY0NvzwQ2XUBGchzYwWslUc5JwHa5KmjP8rZnLpCIPIRalnye1HIUA4Eo
+        QihEoBmsvPyH0/fJYODE0h8LWckJW/zw5fPXT8+HZzRYb5fvOEbyx5pYZa45jVWPml8oCbbrp7XB
+        XPXPv8f9ZPBW/A1s9/t/AAaXBd61i8NZ15N/R5uHafodAAD//6oOpChCAgAA
+    headers:
+      Alt-Svc:
+      - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+      Transfer-Encoding:
+      - chunked
+      Via:
+      - 1.1 google
+      access-control-expose-headers:
+      - X-Debug-Trace-ID
+      cache-control:
+      - no-cache, no-store, no-transform, must-revalidate, private, max-age=0
+      content-encoding:
+      - gzip
+      content-type:
+      - application/json
+      date:
+      - Tue, 03 Feb 2026 03:41:21 GMT
+      expires:
+      - Thu, 01 Jan 1970 00:00:00 GMT
+      num_chars:
+      - '2610'
+      num_tokens:
+      - '321'
+      pragma:
+      - no-cache
+      server:
+      - envoy
+      vary:
+      - Origin,Accept-Encoding
+      x-accel-expires:
+      - '0'
+      x-debug-trace-id:
+      - e86e11e29a316e54213d30ae2e9145d2
+      x-envoy-upstream-service-time:
+      - '1774'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/libs/cohere/tests/integration_tests/cassettes/test_invoke_with_vision_url.yaml
+++ b/libs/cohere/tests/integration_tests/cassettes/test_invoke_with_vision_url.yaml
@@ -1,0 +1,81 @@
+interactions:
+- request:
+    body: '{"model":"command-a-vision-07-2025","messages":[{"role":"user","content":[{"type":"text","text":"What''s
+      in this image?"},{"type":"image_url","image_url":{"url":"https://cohere.com/favicon-32x32.png"}}]}],"stream":false}'
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate, zstd
+      connection:
+      - keep-alive
+      content-length:
+      - '219'
+      content-type:
+      - application/json
+      host:
+      - api.cohere.com
+      user-agent:
+      - cohere/5.18.0
+      x-client-name:
+      - langchain:partner
+      x-fern-language:
+      - Python
+      x-fern-sdk-name:
+      - cohere
+      x-fern-sdk-version:
+      - 5.18.0
+    method: POST
+    uri: https://api.cohere.com/v2/chat
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAA/2xSy27kNhD8lQIvvmgG43k4tq6BDwESJAcDOQSB0SJbUmcoUmG3vJ415t8XFNb7
+        wp6IflRVdzXfnATXurDb7/q9P2744W63OfKBNt2dP21u78Mv/eH+dODu6Bo3sSoN7No3V3Jk1zpS
+        FTVK5hrnczJO5tp/3pxd5lo2fq2V9Wnd08iQiQbGJS83L4y55BcJHCCK/xcxBnVqhbyBUkDIrOnG
+        UIlJEihdEEQ9lyRdZOTuP/amyAXqObFu8ZuhZ7KlsMLGwlwBJskbdKSZtQUhUhkYgcoZQ2FOyC8U
+        QQYbGZbnBgSdKEYuyIXSwPBSfFVMa0+XzfKEyL0166SEiYMs00blIwfMS5lrd6X9HlJkGG2Lp5GV
+        P08EKgxlAw0kSQ2EOdZ1P4zVkY78eSh5SWGFQWWao3ixy6ocyZ+RewQ2koiJzgwxBOl78Us0WAap
+        L9Lx6p/O7KUXj4kpSRqqeevhXtdWez/RaqXPSwyoSEySZKIoapiFPVdNKnV9xDzkpvIQAqsMCRx5
+        4mRb/C025sVAIYhJThQhqc9loho1ELtR5JlT1ZZkXObCtha37vrvtXG9JNHxuTBpTq51v/75x1+/
+        Pz49usYt73+xkxg5PC9JTGssaV7s2fKZk7p2f3dqXF7s29zt7eHauPfoR8Rpt/8ZonGrM1+JTw/X
+        xnnyI4cvyeP97nr9FAAA///So79LVgMAAA==
+    headers:
+      Alt-Svc:
+      - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+      Transfer-Encoding:
+      - chunked
+      Via:
+      - 1.1 google
+      access-control-expose-headers:
+      - X-Debug-Trace-ID
+      cache-control:
+      - no-cache, no-store, no-transform, must-revalidate, private, max-age=0
+      content-encoding:
+      - gzip
+      content-type:
+      - application/json
+      date:
+      - Tue, 03 Feb 2026 03:38:23 GMT
+      expires:
+      - Thu, 01 Jan 1970 00:00:00 GMT
+      num_chars:
+      - '2612'
+      num_tokens:
+      - '378'
+      pragma:
+      - no-cache
+      server:
+      - envoy
+      vary:
+      - Origin,Accept-Encoding
+      x-accel-expires:
+      - '0'
+      x-debug-trace-id:
+      - e2158a96221da247d71a662f9cd696ef
+      x-envoy-upstream-service-time:
+      - '3144'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/libs/cohere/tests/integration_tests/cassettes/test_stream_with_vision.yaml
+++ b/libs/cohere/tests/integration_tests/cassettes/test_stream_with_vision.yaml
@@ -1,0 +1,951 @@
+interactions:
+- request:
+    body: '{"model":"command-a-vision-07-2025","messages":[{"role":"user","content":[{"type":"text","text":"Describe
+      this image briefly"},{"type":"image_url","image_url":{"url":"https://cohere.com/favicon-32x32.png"}}]}],"stream":true}'
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate, zstd
+      connection:
+      - keep-alive
+      content-length:
+      - '224'
+      content-type:
+      - application/json
+      host:
+      - api.cohere.com
+      user-agent:
+      - cohere/5.18.0
+      x-client-name:
+      - langchain:partner
+      x-fern-language:
+      - Python
+      x-fern-sdk-name:
+      - cohere
+      x-fern-sdk-version:
+      - 5.18.0
+    method: POST
+    uri: https://api.cohere.com/v2/chat
+  response:
+    body:
+      string: 'event: message-start
+
+        data: {"id":"24bcc05b-afc9-4f88-aaf1-e8b19eb917c9","type":"message-start","delta":{"message":{"role":"assistant","content":[],"tool_plan":"","tool_calls":[],"citations":[]}}}
+
+
+        event: content-start
+
+        data: {"type":"content-start","index":0,"delta":{"message":{"content":{"type":"text","text":""}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"The"}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"
+        image"}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"
+        you"}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"''ve"}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"
+        provided"}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"
+        is"}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"
+        quite"}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"
+        abstract"}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"
+        and"}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"
+        blurred"}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":","}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"
+        making"}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"
+        it"}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"
+        difficult"}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"
+        to"}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"
+        discern"}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"
+        specific"}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"
+        details"}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"."}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"
+        However"}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":","}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"
+        I"}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"
+        can"}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"
+        describe"}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"
+        the"}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"
+        general"}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"
+        shapes"}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"
+        and"}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"
+        colors"}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"
+        that"}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"
+        are"}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"
+        visible"}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"."}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"\n\nThe"}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"
+        image"}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"
+        appears"}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"
+        to"}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"
+        contain"}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"
+        three"}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"
+        main"}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"
+        shapes"}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":":"}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"\n1"}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"."}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"
+        A"}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"
+        large"}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":","}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"
+        dark"}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"
+        green"}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"
+        oval"}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"
+        shape"}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"
+        at"}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"
+        the"}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"
+        top"}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"."}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"\n2"}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"."}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"
+        A"}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"
+        smaller"}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":","}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"
+        bright"}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"
+        orange"}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"
+        circular"}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"
+        shape"}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"
+        below"}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"
+        and"}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"
+        to"}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"
+        the"}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"
+        left"}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"
+        of"}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"
+        the"}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"
+        green"}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"
+        oval"}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"."}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"\n3"}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"."}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"
+        A"}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"
+        medium"}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"-"}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"sized"}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":","}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"
+        light"}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"
+        purple"}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"
+        oval"}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"
+        shape"}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"
+        below"}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"
+        and"}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"
+        to"}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"
+        the"}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"
+        right"}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"
+        of"}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"
+        the"}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"
+        green"}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"
+        oval"}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"."}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"\n\nThese"}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"
+        shapes"}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"
+        are"}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"
+        set"}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"
+        against"}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"
+        a"}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"
+        white"}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"
+        background"}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"."}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"
+        Due"}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"
+        to"}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"
+        the"}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"
+        bl"}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"urr"}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"iness"}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":","}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"
+        it"}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"''s"}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"
+        challenging"}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"
+        to"}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"
+        provide"}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"
+        more"}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"
+        precise"}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"
+        details"}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"
+        or"}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"
+        to"}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"
+        understand"}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"
+        the"}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"
+        context"}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"
+        or"}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"
+        meaning"}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"
+        behind"}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"
+        these"}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"
+        shapes"}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"."}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"
+        If"}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"
+        you"}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"
+        have"}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"
+        any"}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"
+        specific"}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"
+        questions"}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"
+        about"}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"
+        the"}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"
+        image"}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"
+        or"}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"
+        need"}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"
+        further"}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"
+        clarification"}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":","}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"
+        feel"}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"
+        free"}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"
+        to"}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"
+        ask"}}}}
+
+
+        event: content-delta
+
+        data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"text":"!"}}}}
+
+
+        event: content-end
+
+        data: {"type":"content-end","index":0}
+
+
+        event: message-end
+
+        data: {"type":"message-end","delta":{"finish_reason":"COMPLETE","usage":{"billed_units":{"input_tokens":263,"output_tokens":156},"tokens":{"input_tokens":500,"output_tokens":156,"image_tokens":259},"cached_tokens":480}}}
+
+
+        data: [DONE]
+
+
+        '
+    headers:
+      Alt-Svc:
+      - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+      Transfer-Encoding:
+      - chunked
+      Via:
+      - 1.1 google
+      access-control-expose-headers:
+      - X-Debug-Trace-ID
+      cache-control:
+      - no-cache, no-store, no-transform, must-revalidate, private, max-age=0
+      content-type:
+      - text/event-stream
+      date:
+      - Tue, 03 Feb 2026 03:41:26 GMT
+      expires:
+      - Thu, 01 Jan 1970 00:00:00 GMT
+      pragma:
+      - no-cache
+      server:
+      - envoy
+      vary:
+      - Origin
+      x-accel-expires:
+      - '0'
+      x-debug-trace-id:
+      - 5d71ad93ffdbc9eda2f92ebbe65f58a7
+      x-envoy-upstream-service-time:
+      - '289'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/libs/cohere/tests/integration_tests/test_chat_models.py
+++ b/libs/cohere/tests/integration_tests/test_chat_models.py
@@ -405,3 +405,143 @@ def test_cohere_with_structured_output(
         "The person's name is John, and he is 30 years old"
     )
     assert result == expected
+
+
+# Vision tests for Command A Vision model
+VISION_MODEL = "command-a-vision-07-2025"
+
+
+@pytest.mark.vcr()
+def test_invoke_with_vision_url() -> None:
+    """Test invoking ChatCohere with an image URL."""
+    llm = ChatCohere(model=VISION_MODEL)
+    message = HumanMessage(
+        content=[
+            {"type": "text", "text": "What's in this image?"},
+            {
+                "type": "image_url",
+                "image_url": {"url": "https://cohere.com/favicon-32x32.png"},
+            },
+        ]
+    )
+    result = llm.invoke([message])
+    assert isinstance(result, AIMessage)
+    assert isinstance(result.content, str)
+    assert len(result.content) > 0
+
+
+@pytest.mark.vcr()
+def test_invoke_with_vision_base64() -> None:
+    """Test invoking ChatCohere with a base64 encoded image."""
+    llm = ChatCohere(model=VISION_MODEL)
+    # Small 1x1 red pixel PNG
+    base64_image = (
+        "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8DwHwAFBQIAX8jx"
+        "0gAAAABJRU5ErkJggg=="
+    )
+    message = HumanMessage(
+        content=[
+            {"type": "text", "text": "Describe this image"},
+            {
+                "type": "image_url",
+                "image_url": {
+                    "url": f"data:image/png;base64,{base64_image}",
+                    "detail": "high",
+                },
+            },
+        ]
+    )
+    result = llm.invoke([message])
+    assert isinstance(result, AIMessage)
+    assert isinstance(result.content, str)
+    assert len(result.content) > 0
+
+
+@pytest.mark.vcr()
+def test_invoke_with_multiple_images() -> None:
+    """Test invoking ChatCohere with multiple images."""
+    llm = ChatCohere(model=VISION_MODEL)
+    message = HumanMessage(
+        content=[
+            {"type": "text", "text": "Compare these two images"},
+            {
+                "type": "image_url",
+                "image_url": {"url": "https://cohere.com/favicon-32x32.png"},
+            },
+            {
+                "type": "image_url",
+                "image_url": {
+                    "url": "https://cohere.com/favicon-32x32.png",
+                    "detail": "low",
+                },
+            },
+        ]
+    )
+    result = llm.invoke([message])
+    assert isinstance(result, AIMessage)
+    assert isinstance(result.content, str)
+    assert len(result.content) > 0
+
+
+@pytest.mark.vcr()
+async def test_astream_with_vision() -> None:
+    """Test async streaming with vision inputs."""
+    llm = ChatCohere(model=VISION_MODEL)
+    message = HumanMessage(
+        content=[
+            {"type": "text", "text": "What's in this image?"},
+            {
+                "type": "image_url",
+                "image_url": {"url": "https://cohere.com/favicon-32x32.png"},
+            },
+        ]
+    )
+
+    full: Optional[BaseMessageChunk] = None
+    async for token in llm.astream([message]):
+        assert isinstance(token, AIMessageChunk)
+        full = token if full is None else full + token
+
+    assert isinstance(full, AIMessageChunk)
+    assert isinstance(full.content, str)
+    assert len(full.content) > 0
+
+
+@pytest.mark.vcr()
+def test_stream_with_vision() -> None:
+    """Test streaming with vision inputs."""
+    llm = ChatCohere(model=VISION_MODEL)
+    message = HumanMessage(
+        content=[
+            {"type": "text", "text": "Describe this image briefly"},
+            {
+                "type": "image_url",
+                "image_url": {"url": "https://cohere.com/favicon-32x32.png"},
+            },
+        ]
+    )
+
+    full: Optional[BaseMessageChunk] = None
+    for chunk in llm.stream([message]):
+        assert isinstance(chunk, AIMessageChunk)
+        full = chunk if full is None else full + chunk
+
+    assert isinstance(full, AIMessageChunk)
+    assert isinstance(full.content, str)
+    assert len(full.content) > 0
+
+
+@pytest.mark.vcr()
+def test_invoke_with_text_only_list() -> None:
+    """Test that text-only content in list format still works."""
+    llm = ChatCohere(model=VISION_MODEL)
+    message = HumanMessage(
+        content=[
+            {"type": "text", "text": "Hello, "},
+            {"type": "text", "text": "how are you?"},
+        ]
+    )
+    result = llm.invoke([message])
+    assert isinstance(result, AIMessage)
+    assert isinstance(result.content, str)
+    assert len(result.content) > 0


### PR DESCRIPTION
## Summary

- Add vision (image input) support for Command A Vision model (`command-a-vision-07-2025`) to the `langchain-cohere` package
- Introduce `_convert_content_to_cohere_format()` in `chat_models.py` to translate LangChain's multi-modal content format into Cohere SDK `TextContent` / `ImageUrlContent` objects
- Support image URLs, base64-encoded data URIs, multiple images per request, and configurable detail levels (`low`, `high`, `auto`)
- Add Vision documentation section to README with usage examples
- Add validation script (`examples/vision_example.py`) for manual smoke testing

## Changes

| File | What changed |
|------|-------------|
| `libs/cohere/langchain_cohere/chat_models.py` | Added `ImageUrlContent`/`TextContent` imports, new `_convert_content_to_cohere_format()` function, updated `HumanMessage` handling to route through it |
| `libs/cohere/README.md` | New "Vision (Image Inputs)" section with URL, base64, and multi-image examples |
| `libs/cohere/tests/integration_tests/test_chat_models.py` | 6 new tests: `test_invoke_with_vision_url`, `test_invoke_with_vision_base64`, `test_invoke_with_multiple_images`, `test_astream_with_vision`, `test_stream_with_vision`, `test_invoke_with_text_only_list` |
| `libs/cohere/tests/integration_tests/cassettes/` | 6 new VCR cassette YAML files for replay testing |
| `libs/cohere/examples/vision_example.py` | CLI script for manual validation |

## Validation

**Automated tests** — ran the full integration test suite with VCR cassettes:

```
20 passed, 5 failed, 1 xfailed in 4.16s
```

- All 6 new vision tests passed
- All 14 pre-existing VCR-backed tests passed
- 5 pre-existing failures are tests without `@pytest.mark.vcr()` that require a live API key (unrelated to this change)

**Manual validation** — reviewers can run:

```bash
export COHERE_API_KEY=your-key
python libs/cohere/examples/vision_example.py
python libs/cohere/examples/vision_example.py --image https://your-image-url.jpg --prompt "Describe this"
```