### PR TITLE
Bump release version to 0.6.0

### DIFF
--- a/libs/cohere/pyproject.toml
+++ b/libs/cohere/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "langchain-cohere"
-version = "0.5.1"
+version = "0.6.0"
 description = "An integration package connecting Cohere and LangChain"
 authors = []
 readme = "README.md"


### PR DESCRIPTION
Main change in this version is support around Command A Vision.
This will allow users to use this library against Command A+