### PR TITLE
fix(cohere): populate `llm_output` with token usage and model name in `_generate` / `_agenerate`

### DIFF
--- a/libs/cohere/langchain_cohere/chat_models.py
+++ b/libs/cohere/langchain_cohere/chat_models.py
@@ -1369,10 +1369,14 @@ class ChatCohere(BaseChatModel, BaseCohere):
             tool_calls=tool_calls,
             usage_metadata=usage_metadata,
         )
+        llm_output: Dict[str, Any] = {"model_name": self.model_name}
+        if token_count := generation_info.get("token_count"):
+            llm_output["token_usage"] = token_count
         return ChatResult(
             generations=[
                 ChatGeneration(message=message, generation_info=generation_info)
-            ]
+            ],
+            llm_output=llm_output,
         )
 
     async def _agenerate(
@@ -1418,10 +1422,14 @@ class ChatCohere(BaseChatModel, BaseCohere):
             tool_calls=tool_calls,
             usage_metadata=usage_metadata,
         )
+        llm_output: Dict[str, Any] = {"model_name": self.model_name}
+        if token_count := generation_info.get("token_count"):
+            llm_output["token_usage"] = token_count
         return ChatResult(
             generations=[
                 ChatGeneration(message=message, generation_info=generation_info)
-            ]
+            ],
+            llm_output=llm_output,
         )
 
     @property

--- a/libs/cohere/tests/unit_tests/test_chat_models.py
+++ b/libs/cohere/tests/unit_tests/test_chat_models.py
@@ -1378,3 +1378,59 @@ def test_get_cohere_chat_request_v2_warn_connectors_deprecated(
     assert issubclass(warning.category, DeprecationWarning)
     assert "connectors" in str(warning.message)
     assert "deprecated" in str(warning.message)
+
+
+def test_generate_populates_llm_output(
+    patch_base_cohere_get_default_model: Generator[Optional[BaseCohere], None, None],
+) -> None:
+    """_generate should populate llm_output with token_usage and model_name."""
+    from langchain_core.messages import HumanMessage
+
+    chat_cohere = ChatCohere(cohere_api_key="test", model="command-r-plus")
+
+    response = ChatResponse(
+        id="test-id",
+        finish_reason="COMPLETE",
+        message=AssistantMessageResponse(
+            content=[{"type": "text", "text": "Hello!"}],
+            tool_calls=None,
+            tool_plan=None,
+            citations=None,
+        ),
+        usage=Usage(tokens=UsageTokens(input_tokens=10, output_tokens=5)),
+    )
+
+    with patch.object(chat_cohere.client.v2, "chat", return_value=response):
+        result = chat_cohere._generate([HumanMessage(content="Hi")])
+
+    assert result.llm_output is not None
+    assert result.llm_output["model_name"] == "command-r-plus"
+    assert result.llm_output["token_usage"] == {"input_tokens": 10, "output_tokens": 5}
+
+
+def test_generate_llm_output_without_token_count(
+    patch_base_cohere_get_default_model: Generator[Optional[BaseCohere], None, None],
+) -> None:
+    """llm_output should still be populated with model_name when token_count is absent."""
+    from langchain_core.messages import HumanMessage
+
+    chat_cohere = ChatCohere(cohere_api_key="test", model="command-r-plus")
+
+    response = ChatResponse(
+        id="test-id",
+        finish_reason="COMPLETE",
+        message=AssistantMessageResponse(
+            content=[{"type": "text", "text": "Hello!"}],
+            tool_calls=None,
+            tool_plan=None,
+            citations=None,
+        ),
+        usage=None,
+    )
+
+    with patch.object(chat_cohere.client.v2, "chat", return_value=response):
+        result = chat_cohere._generate([HumanMessage(content="Hi")])
+
+    assert result.llm_output is not None
+    assert result.llm_output["model_name"] == "command-r-plus"
+    assert "token_usage" not in result.llm_output


### PR DESCRIPTION
Closes #151

`ChatCohere._generate` and `_agenerate` returned `ChatResult` without setting `llm_output`, so `BaseCallbackHandler.on_llm_end` always received `response.llm_output = None`. Token usage was available in `generation_info["token_count"]` but was never exposed in the field that callbacks rely on.

**Change**: both non-streaming return paths now set:
```python
llm_output = {
    "model_name": self.model_name,
    "token_usage": generation_info["token_count"],  # omitted when absent
}
```

`token_usage` is only included when `token_count` is present so callers can safely check for its existence rather than handling `None`. The streaming path (`generate_from_stream` / `agenerate_from_stream`) is unaffected by this change.

Two unit tests are added: one verifying the happy path (token usage populated), one verifying that `model_name` is always present even when the API omits usage data.

This contribution was made with AI-agent assistance.