### PR TITLE
chore(cohere): replace deprecated `ChatResponse` import with explicit `V2ChatResponse`

### DIFF
--- a/libs/cohere/langchain_cohere/chat_models.py
+++ b/libs/cohere/langchain_cohere/chat_models.py
@@ -19,7 +19,6 @@ from typing import (
 from cohere import (
     AssistantChatMessageV2,
     ChatMessageV2,
-    ChatResponse,
     DocumentToolContent,
     ImageUrlContent,
     NonStreamedChatResponse,
@@ -30,6 +29,7 @@ from cohere import (
     ToolCallV2Function,
     ToolChatMessageV2,
     UserChatMessageV2,
+    V2ChatResponse as ChatResponse,
 )
 from cohere import Document as DocumentV2
 from langchain_core._api.deprecation import deprecated, warn_deprecated

--- a/libs/cohere/tests/unit_tests/test_chat_models.py
+++ b/libs/cohere/tests/unit_tests/test_chat_models.py
@@ -8,7 +8,6 @@ from cohere import (
     AssistantChatMessageV2,
     AssistantMessageResponse,
     ChatMessageEndEventDelta,
-    ChatResponse,
     NonStreamedChatResponse,
     SystemChatMessageV2,
     ToolCall,
@@ -21,6 +20,7 @@ from cohere import (
     UsageBilledUnits,
     UsageTokens,
     UserChatMessageV2,
+    V2ChatResponse as ChatResponse,
 )
 from langchain_core.documents import Document
 from langchain_core.messages import AIMessage, BaseMessage, HumanMessage, ToolMessage


### PR DESCRIPTION
Closes #146

`ChatResponse` re-exported from `cohere` is a runtime alias for `V2ChatResponse` (verified: `ChatResponse is V2ChatResponse` → `True`). Keeping the alias import obscures which SDK generation is being used and risks a silent break if the alias is removed in a future Cohere SDK release.

**Change**: `from cohere import ChatResponse` → `from cohere import V2ChatResponse as ChatResponse` in both the implementation and test files. All existing type annotations (`response: ChatResponse`, return-type hints, etc.) remain unchanged — only the import line differs.

All 31 existing unit tests pass without modification.

This contribution was made with AI-agent assistance.