### PR TITLE
fix: keep JSON Schema constraints when converting tools for Cohere v2

### DIFF
--- a/libs/cohere/langchain_cohere/cohere_agent.py
+++ b/libs/cohere/langchain_cohere/cohere_agent.py
@@ -179,19 +179,22 @@ def _convert_to_cohere_tool_v2(
                     "properties": {
                         param_name: {
                             "description": param_definition.get("description", ""),
-                            "type": param_definition.get("type"),
+                            **param_definition,
                         }
                         for param_name, param_definition in tool.get(
                             "properties", {}
                         ).items()
                     },
-                    "required": [
-                        param_name
-                        for param_name, param_definition in tool.get(
-                            "properties", {}
-                        ).items()
-                        if "default" not in param_definition
-                    ],
+                    "required": tool.get(
+                        "required",
+                        [
+                            param_name
+                            for param_name, param_definition in tool.get(
+                                "properties", {}
+                            ).items()
+                            if "default" not in param_definition
+                        ],
+                    ),
                 },
             ),
         )
@@ -206,23 +209,22 @@ def _convert_to_cohere_tool_v2(
         parameter_definitions = {}
         required_params = []
         for param_name, param_definition in properties.items():
-            if "type" in param_definition:
-                _type = param_definition.get("type")
-            elif "anyOf" in param_definition:
-                _type = next(
+            tool_definition = dict(param_definition)
+            if "type" not in tool_definition and "anyOf" in tool_definition:
+                # Optional[...] arrives as anyOf[<T>, null]. Resolve it to the
+                # concrete branch and carry that branch's schema (enum, items,
+                # nested properties, ...) instead of dropping it.
+                non_null: Dict[str, Any] = next(
                     (
-                        t.get("type")
-                        for t in param_definition.get("anyOf", [])
-                        if t.get("type") != "null"
+                        sub
+                        for sub in tool_definition["anyOf"]
+                        if sub.get("type") != "null"
                     ),
-                    param_definition.get("type"),
+                    {},
                 )
-            else:
-                _type = None
-            tool_definition = {
-                "type": _type,
-                "description": param_definition.get("description", ""),
-            }
+                tool_definition.pop("anyOf")
+                tool_definition = {**non_null, **tool_definition}
+            tool_definition.setdefault("description", "")
             parameter_definitions[param_name] = tool_definition
             if param_name in parameters.get("required", []):
                 required_params.append(param_name)

--- a/libs/cohere/tests/unit_tests/test_chat_models.py
+++ b/libs/cohere/tests/unit_tests/test_chat_models.py
@@ -1,6 +1,6 @@
 """Test chat model integration."""
 
-from typing import Any, Dict, Generator, List, Optional
+from typing import Any, Dict, Generator, List, Literal, Optional
 from unittest.mock import patch
 
 import pytest
@@ -25,6 +25,7 @@ from cohere import (
 from langchain_core.documents import Document
 from langchain_core.messages import AIMessage, BaseMessage, HumanMessage, ToolMessage
 from langchain_core.tools import tool
+from pydantic import BaseModel, Field
 from pytest import WarningsRecorder
 
 from langchain_cohere.chat_models import (
@@ -1359,6 +1360,32 @@ def test_format_to_cohere_tools_v2() -> None:
     ]
 
     assert result == expected
+
+
+def test_format_to_cohere_tools_v2_preserves_schema_constraints() -> None:
+    class Address(BaseModel):
+        street: str
+        city: str
+
+    class CreateContact(BaseModel):
+        """Create a contact."""
+
+        name: str
+        role: Literal["admin", "user"] = Field(description="access role")
+        email: Optional[str] = None
+        address: Address
+
+    params = _format_to_cohere_tools_v2([CreateContact])[0].function.parameters
+    props = params["properties"]
+
+    # Literal -> enum must survive.
+    assert props["role"]["enum"] == ["admin", "user"]
+    # Nested BaseModel keeps its inner schema, not flattened to a bare object.
+    assert props["address"]["properties"]["street"]["type"] == "string"
+    assert props["address"]["required"] == ["street", "city"]
+    # Optional[str] resolves to its concrete type.
+    assert props["email"]["type"] == "string"
+    assert params["required"] == ["name", "role", "address"]
 
 
 def test_get_cohere_chat_request_v2_warn_connectors_deprecated(


### PR DESCRIPTION
Fixes #157.

`bind_tools` ran every tool parameter through `_convert_to_cohere_tool_v2`, which rebuilt each one as just `type` and `description`. So a Literal lost its `enum`, a nested model lost its `properties`, and `constr`/`Field` constraints got dropped. Cohere v2 takes a full JSON Schema in `parameters`, so I pass it through instead and only collapse `Optional[...]` down to its concrete type. The dict path now also honors an explicit `required` array.

Added a test in `test_chat_models.py` with a Literal, a nested model, and an Optional field. Fails on `main`, and the rest of the suite still passes.